### PR TITLE
Add uuid support

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -13,10 +13,14 @@ import re
 
 app = FastAPI()
 
-# Setup persistent session for making http requests
+# Setup data cache and downstream requests session
 @app.on_event('startup')
 async def startup_event():
   app.client_session = ClientSession()
+  with open('data/blast_config.json') as f:
+    app.blast_config = json.load(f)
+  with open('data/genome_ids.json') as f:
+    app.genome_ids = json.load(f)
 
 @app.on_event('shutdown')
 async def shutdown_event():
@@ -40,9 +44,7 @@ async def upstream_connection_handler(request, exception):
 # Endpoint for serving the BLAST config
 @app.get('/blast/config')
 async def serve_config() -> dict:
-  with open('data/blast_config.json') as f:
-   config = json.load(f)
-  return config
+  return app.blast_config
 
 # Validate job submission payload
 class Program(str, Enum):

--- a/app/main.py
+++ b/app/main.py
@@ -85,7 +85,7 @@ class JobIDs(BaseModel):
 # Infer the target species index file for BLAST payload
 def get_blast_filename(genome_id: str, db_type: str) -> str:
   suffix = f'{db_type}.toplevel' if db_type == 'dna' else f'{db_type}.all'
-  return f'ensembl/{genome_id}/{db_type}/{genome_id}.{suffix}'
+  return f'ensembl/{app.genome_ids[genome_id]}/{db_type}/{app.genome_ids[genome_id]}.{suffix}'
 
 # Submit a BLAST job to JD. Returns a resolvable for fetching the response.
 async def run_blast(query: dict, blast_payload: dict, genome_id: str, db_type: str) -> dict:
@@ -118,6 +118,7 @@ async def submit_blast(payload: BlastJob) -> dict:
 @app.get("/blast/jobs/status/{job_id}")
 async def blast_job_status(job_id: str) -> dict:
   resp = await blast_proxy('status', job_id)
+  #if resp['status'] == 'NOT_FOUND': response.status_code = 404
   resp['job_id'] = job_id
   return resp
 

--- a/app/main.py
+++ b/app/main.py
@@ -91,7 +91,7 @@ def get_blast_filename(genome_id: str, db_type: str) -> str:
 async def run_blast(query: dict, blast_payload: dict, genome_id: str, db_type: str) -> dict:
   blast_payload['sequence'] = query['value']
   blast_payload['database'] = get_blast_filename(genome_id, db_type)
-  url = 'http://wwwdev.ebi.ac.uk/Tools/services/rest/ncbiblast_ensembl/run'
+  url = 'http://ebi.ac.uk/Tools/services/rest/ncbiblast_ensembl/run'
   async with app.client_session.post(url, data = blast_payload) as resp:
     response = await resp.text()
     if resp.status == 200:
@@ -133,7 +133,7 @@ async def blast_job_statuses(payload: JobIDs) -> dict:
 # Proxy for JD BLAST REST API endpoints (/status/:id, /result/:id/:type)
 @app.get("/blast/jobs/{action}/{params:path}")
 async def blast_proxy(action: str, params: str, response: Response = None) -> dict:
-  url = f"http://wwwdev.ebi.ac.uk/Tools/services/rest/ncbiblast_ensembl/{action}/{params}"
+  url = f"http://ebi.ac.uk/Tools/services/rest/ncbiblast_ensembl/{action}/{params}"
   async with app.client_session.get(url) as resp:
     if response: response.status_code = resp.status #forward the status code from JD
     content = await resp.text()

--- a/app/main.py
+++ b/app/main.py
@@ -91,7 +91,7 @@ def get_blast_filename(genome_id: str, db_type: str) -> str:
 async def run_blast(query: dict, blast_payload: dict, genome_id: str, db_type: str) -> dict:
   blast_payload['sequence'] = query['value']
   blast_payload['database'] = get_blast_filename(genome_id, db_type)
-  url = 'http://ebi.ac.uk/Tools/services/rest/ncbiblast_ensembl/run'
+  url = 'http://www.ebi.ac.uk/Tools/services/rest/ncbiblast_ensembl/run'
   async with app.client_session.post(url, data = blast_payload) as resp:
     response = await resp.text()
     if resp.status == 200:
@@ -133,7 +133,7 @@ async def blast_job_statuses(payload: JobIDs) -> dict:
 # Proxy for JD BLAST REST API endpoints (/status/:id, /result/:id/:type)
 @app.get("/blast/jobs/{action}/{params:path}")
 async def blast_proxy(action: str, params: str, response: Response = None) -> dict:
-  url = f"http://ebi.ac.uk/Tools/services/rest/ncbiblast_ensembl/{action}/{params}"
+  url = f"http://www.ebi.ac.uk/Tools/services/rest/ncbiblast_ensembl/{action}/{params}"
   async with app.client_session.get(url) as resp:
     if response: response.status_code = resp.status #forward the status code from JD
     content = await resp.text()

--- a/app/main.py
+++ b/app/main.py
@@ -91,7 +91,7 @@ def get_blast_filename(genome_id: str, db_type: str) -> str:
 async def run_blast(query: dict, blast_payload: dict, genome_id: str, db_type: str) -> dict:
   blast_payload['sequence'] = query['value']
   blast_payload['database'] = get_blast_filename(genome_id, db_type)
-  url = 'http://wwwdev.ebi.ac.uk/Tools/services/rest/ncbiblast/run'
+  url = 'http://wwwdev.ebi.ac.uk/Tools/services/rest/ncbiblast_ensembl/run'
   async with app.client_session.post(url, data = blast_payload) as resp:
     response = await resp.text()
     if resp.status == 200:
@@ -133,7 +133,7 @@ async def blast_job_statuses(payload: JobIDs) -> dict:
 # Proxy for JD BLAST REST API endpoints (/status/:id, /result/:id/:type)
 @app.get("/blast/jobs/{action}/{params:path}")
 async def blast_proxy(action: str, params: str, response: Response = None) -> dict:
-  url = f"http://wwwdev.ebi.ac.uk/Tools/services/rest/ncbiblast/{action}/{params}"
+  url = f"http://wwwdev.ebi.ac.uk/Tools/services/rest/ncbiblast_ensembl/{action}/{params}"
   async with app.client_session.get(url) as resp:
     if response: response.status_code = resp.status #forward the status code from JD
     content = await resp.text()

--- a/app/tests/blast_payload.json
+++ b/app/tests/blast_payload.json
@@ -1,5 +1,5 @@
 {
-    "genome_ids": ["a733550b-93e7-11ec-a39d-005056b38ce"],
+    "genome_ids": ["a733550b-93e7-11ec-a39d-005056b38ce3"],
     "query_sequences": [
         { "id": 1, "value": "MPIGSKERPTFFEIFKTRCNKADLGPISLNWFEELSS" }
     ],

--- a/app/tests/blast_payload.json
+++ b/app/tests/blast_payload.json
@@ -1,5 +1,5 @@
 {
-    "genome_ids": ["caenorhabditis_elegans_GCA_000002985_3"],
+    "genome_ids": ["a733550b-93e7-11ec-a39d-005056b38ce"],
     "query_sequences": [
         { "id": 1, "value": "MPIGSKERPTFFEIFKTRCNKADLGPISLNWFEELSS" }
     ],

--- a/app/tests/test_main.py
+++ b/app/tests/test_main.py
@@ -45,7 +45,7 @@ def test_blast_job(blast_payload):
 		assert 'sequence_id' in job
 		assert 'genome_id' in job
 		assert 'job_id' in job
-		assert job['job_id'].startswith('ncbiblast-')
+		assert job['job_id'].startswith('ncbiblast')
 		assert 'sequence_id' in job and job['sequence_id'] == 1
 
 # Test multiple BLAST job submission with a valid payload
@@ -61,7 +61,7 @@ def test_blast_jobs(blast_payload):
 		assert len(resp['jobs']) == 4
 		job = resp['jobs'][3]
 		assert 'genome_id' in job and job['genome_id'] == blast_payload['genome_ids'][0]
-		assert 'job_id' in job and job['job_id'].startswith('ncbiblast-')
+		assert 'job_id' in job and job['job_id'].startswith('ncbiblast')
 		assert 'sequence_id' in job and job['sequence_id'] == 2
 
 # Test incoming payload validation for BLAST job submission
@@ -92,11 +92,12 @@ def test_blast_job_jd_error(blast_payload):
 # Test BLAST job status endpoint
 def test_blast_job_status():
 	with TestClient(app) as client:
-		response = client.get('/blast/jobs/status/ncbiblast-12345')
+		response = client.get('/blast/jobs/status/ncbiblast_ensembl-12345')
 		assert response.status_code == 200
 		assert 'status' in response.json()
 
 # Test multiple jobs status endpoint
+# Example job id: ncbiblast_ensembl-R20220907-111749-0693-28451168-np2
 def test_blast_job_statuses():
 	with TestClient(app) as client:
 		job_ids = {'job_ids': ['ncbiblast-1234', 'ncbiblast-5678']}

--- a/app/tests/test_main.py
+++ b/app/tests/test_main.py
@@ -6,12 +6,12 @@ from ..main import get_blast_filename
 
 # Test config endpoint
 def test_read_config():
-	client = TestClient(app)
-	with open('data/blast_config.json') as f:
-		config = json.load(f)
-	response = client.get('/blast/config')
-	assert response.status_code == 200
-	assert response.json() == config
+	with TestClient(app) as client: #include @startup hook
+		with open('data/blast_config.json') as f:
+			config = json.load(f)
+		response = client.get('/blast/config')
+		assert response.status_code == 200
+		assert response.json() == config
 
 # Load example BLAST job payload
 @pytest.fixture
@@ -31,7 +31,7 @@ def test_get_blast_filename(blast_payload):
 
 # Test single BLAST job submission with a valid payload
 def test_blast_job(blast_payload):
-	with TestClient(app) as client: #include @startup hook
+	with TestClient(app) as client:
 		response = client.post('/blast/job', json=blast_payload)
 		assert response.status_code == 200
 		resp = response.json()

--- a/data/genome_ids.json
+++ b/data/genome_ids.json
@@ -1,9 +1,9 @@
 {
-	"caenorhabditis_elegans_GCA_000002985_3": "a733550b-93e7-11ec-a39d-005056b38ce",
-  "escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845_2": "a73351f7-93e7-11ec-a39d-005056b38ce3",
-  "homo_sapiens_GCA_000001405_14": "3704ceb1-948d-11ec-a39d-005056b38ce3",
-  "homo_sapiens_GCA_000001405_28": "a7335667-93e7-11ec-a39d-005056b38ce3",
-  "plasmodium_falciparum_GCA_000002765_2": "a73356e1-93e7-11ec-a39d-005056b38ce3",
-  "saccharomyces_cerevisiae_GCA_000146045_2": "a733574a-93e7-11ec-a39d-005056b38ce3",
-  "triticum_aestivum_GCA_900519105_1": "a73357ab-93e7-11ec-a39d-005056b38ce3"
+  "a733550b-93e7-11ec-a39d-005056b38ce": "caenorhabditis_elegans_GCA_000002985_3",
+  "a73351f7-93e7-11ec-a39d-005056b38ce3": "escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845_2",
+  "3704ceb1-948d-11ec-a39d-005056b38ce3": "homo_sapiens_GCA_000001405_14",
+  "a7335667-93e7-11ec-a39d-005056b38ce3": "homo_sapiens_GCA_000001405_28",
+  "a73356e1-93e7-11ec-a39d-005056b38ce3": "plasmodium_falciparum_GCA_000002765_2",
+  "a733574a-93e7-11ec-a39d-005056b38ce3": "saccharomyces_cerevisiae_GCA_000146045_2",
+  "a73357ab-93e7-11ec-a39d-005056b38ce3": "triticum_aestivum_GCA_900519105_1"
 }

--- a/data/genome_ids.json
+++ b/data/genome_ids.json
@@ -1,5 +1,5 @@
 {
-  "a733550b-93e7-11ec-a39d-005056b38ce": "caenorhabditis_elegans_GCA_000002985_3",
+  "a733550b-93e7-11ec-a39d-005056b38ce3": "caenorhabditis_elegans_GCA_000002985_3",
   "a73351f7-93e7-11ec-a39d-005056b38ce3": "escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845_2",
   "3704ceb1-948d-11ec-a39d-005056b38ce3": "homo_sapiens_GCA_000001405_14",
   "a7335667-93e7-11ec-a39d-005056b38ce3": "homo_sapiens_GCA_000001405_28",

--- a/data/genome_ids.json
+++ b/data/genome_ids.json
@@ -1,9 +1,9 @@
 {
-	"celegans": "caenorhabditis_elegans_GCA_000002985_3",
-  "plasmodium": "plasmodium_falciparum_GCA_000002765_2",
-  "ecoli": "escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845_2",
-  "yeast": "saccharomyces_cerevisiae_GCA_000146045_2",
-  "human37": "homo_sapiens_GCA_000001405_14",
-  "wheat": "triticum_aestivum_GCA_900519105_1",
-  "human38": "homo_sapiens_GCA_000001405_28"
+	"caenorhabditis_elegans_GCA_000002985_3": "a733550b-93e7-11ec-a39d-005056b38ce",
+  "escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845_2": "a73351f7-93e7-11ec-a39d-005056b38ce3",
+  "homo_sapiens_GCA_000001405_14": "3704ceb1-948d-11ec-a39d-005056b38ce3",
+  "homo_sapiens_GCA_000001405_28": "a7335667-93e7-11ec-a39d-005056b38ce3",
+  "plasmodium_falciparum_GCA_000002765_2": "a73356e1-93e7-11ec-a39d-005056b38ce3",
+  "saccharomyces_cerevisiae_GCA_000146045_2": "a733574a-93e7-11ec-a39d-005056b38ce3",
+  "triticum_aestivum_GCA_900519105_1": "a73357ab-93e7-11ec-a39d-005056b38ce3"
 }


### PR DESCRIPTION
This PR updates Tools API to support BLAST job submissions with new genome ids, and adds genome id mapping to continue using jDispatcher BLAST server with GCA genome IDs.

JIRA ticket: https://www.ebi.ac.uk/panda/jira/browse/EWB-236
Review app: http://refactor-genomeid.review.ensembl.org