### PR TITLE
Add open api spec for VEP results payload

### DIFF
--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -128,7 +128,6 @@ components:
             - region_name
             - start
             - end
-
         reference_allele:
           $ref: '#/components/schemas/ReferenceVariantAllele'
         alternative_alleles:

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -33,6 +33,24 @@ paths:
                 $ref: '#/components/schemas/VepResultsResponse'
 components:
   schemas:
+    AlternativeVariantAllele:
+      type: object
+      required:
+        - allele_sequence
+        - allele_type
+        - predicted_molecular_consequences
+      properties:
+        allele_sequence:
+          type: string
+        allele_type:
+          type: string
+        representative_population_allele_frequency:
+          type: number
+          nullable: true
+        predicted_molecular_consequences:
+          type: array
+          items:
+            $ref: '#/components/schemas/PredictedTranscriptConsequence'
     PaginationMetadata:
       type: object
       required:
@@ -77,6 +95,13 @@ components:
           enum:
             - forward
             - reverse
+    ReferenceVariantAllele:
+      type: object
+      required:
+        - allele_sequence
+      properties:
+        allele_sequence:
+          type: string
     Variant:
       type: object
       required:
@@ -90,54 +115,26 @@ components:
           type: string
           nullable: true
           description: User's name for the variant; optional
-        slice:
+        location:
           type: object
           properties:
-            region:
-              type: object
-              properties:
-                name:
-                  type: string
-              required:
-                - name
-            location:
-              type: object
-              properties:
-                start:
-                  type: number
-                end:
-                  type: number
-              required:
-                - start
-                - end
+            region_name:
+              type: string
+            start:
+              type: number
+            end:
+              type: number
           required:
-            - region
-            - location
+            - region_name
+            - start
+            - end
+
         reference_allele:
-          $ref: '#/components/schemas/VariantAllele'
+          $ref: '#/components/schemas/ReferenceVariantAllele'
         alternative_alleles:
           type: array
           items:
-            $ref: '#/components/schemas/VariantAllele'
-    VariantAllele:
-      type: object
-      required:
-        - allele_sequence
-        - allele_type
-        - predicted_molecular_consequences
-      properties:
-        allele_sequence:
-          type: string
-        allele_type:
-          type: string
-          description: For reference allele, the value of allele_type is 'biological_region'
-        representative_population_allele_frequency:
-          type: number
-          nullable: true
-        predicted_molecular_consequences:
-          type: array
-          items:
-            $ref: '#/components/schemas/PredictedTranscriptConsequence'
+            $ref: '#/components/schemas/AlternativeVariantAllele'
     VepResultsResponse:
       type: object
       required:

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -1,0 +1,157 @@
+openapi: 3.0.0
+info:
+  title: Tools api
+  version: 0.0.1
+paths:
+  /api/tools/vep/submissions/{id}:
+    get:
+      description: Returns results of VEP analysis
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: number
+            default: 1
+        - name: per_page
+          in: query
+          required: false
+          schema:
+            type: number
+            default: 100
+      responses:
+        '200':
+          description: Successful operaiton.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VepResultsResponse'
+components:
+  schemas:
+    PaginationMetadata:
+      type: object
+      required:
+        - page
+        - per_page
+        - total
+      properties:
+        page:
+          type: number
+        per_page:
+          type: number
+        total:
+          type: number
+    PredictedTranscriptConsequence:
+      type: object
+      required:
+        - feature_type
+        - stable_id
+        - gene_stable_id
+        - biotype
+        - consequences
+        - strand
+      properties:
+        feature_type:
+          type: string
+          enum:
+            - transcript
+        stable_id:
+          type: string
+          description: transcript stable id, versioned
+        gene_stable_id:
+          type: string
+          description: gene stable id, versioned
+        biotype:
+          type: string
+        consequences:
+          type: array
+          items:
+            type: string
+        strand:
+          type: string
+          enum:
+            - forward
+            - reverse
+    Variant:
+      type: object
+      required:
+        - name
+        - allele_type
+        - slice
+        - reference_allele
+        - alternative_alleles
+      properties:
+        name:
+          type: string
+          nullable: true
+          description: User's name for the variant; optional
+        slice:
+          type: object
+          properties:
+            region:
+              type: object
+              properties:
+                name:
+                  type: string
+              required:
+                - name
+            location:
+              type: object
+              properties:
+                start:
+                  type: number
+                end:
+                  type: number
+              required:
+                - start
+                - end
+          required:
+            - region
+            - location
+        reference_allele:
+          $ref: '#/components/schemas/VariantAllele'
+        alternative_alleles:
+          type: array
+          items:
+            $ref: '#/components/schemas/VariantAllele'
+    VariantAllele:
+      type: object
+      required:
+        - allele_sequence
+        - allele_type
+        - predicted_molecular_consequences
+      properties:
+        allele_sequence:
+          type: string
+        allele_type:
+          type: string
+          description: For reference allele, the value of allele_type is 'biological_region'
+        representative_population_allele_frequency:
+          type: number
+          nullable: true
+        predicted_molecular_consequences:
+          type: array
+          items:
+            $ref: '#/components/schemas/PredictedTranscriptConsequence'
+    VepResultsResponse:
+      type: object
+      required:
+        - metadata
+        - variants
+      properties:
+        metadata:
+          type: object
+          properties:
+            pagination:
+              $ref: '#/components/schemas/PaginationMetadata'
+          required:
+            - pagination
+        variants:
+          type: array
+          items:
+            $ref: '#/components/schemas/Variant'

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -3,7 +3,7 @@ info:
   title: Tools api
   version: 0.0.1
 paths:
-  /api/tools/vep/submissions/{id}:
+  /api/tools/vep/submissions/{id}/results:
     get:
       description: Returns results of VEP analysis
       parameters:
@@ -71,6 +71,7 @@ components:
         - stable_id
         - gene_stable_id
         - biotype
+        - is_canonical
         - consequences
         - strand
       properties:
@@ -86,6 +87,8 @@ components:
           description: gene stable id, versioned
         biotype:
           type: string
+        is_canonical:
+          type: boolean
         consequences:
           type: array
           items:


### PR DESCRIPTION
This PR adds an openAPI spec file with the spec for the first endpoint, reporting the results of a VEP analysis.

### Questions for discussion

1. **Should reference allele be shaped the same as alternative allele?**

The biggest question for me is whether it makes sense to model the reference allele and the alternative alleles the same, or they are clearly distinct. For example, the reference allele has a constant `allele_type` (in hypsipyle, it is reported as "biological_region"), which has no value if reference allele is separated into its own field. Similarly, reference allele is not going to have any predicted molecular consequences (i.e. it will always be an empty array).

**DECIDED DURING CODE REVIEW:** Model reference allele and the alternative allele as two distinct objects. I have confirmed with the Variation team that reference alleles do not have predicted molecular consequences.

2. **Is it worth modelling variant's location through the typical slice shape?**

Should the location information be kept inside a nested `slice: { region: {name}, location: {start,end} }` structure, or does it make more sense to just have these fields (`region_name`, `start`, `end`) at the top level?

**DECIDED DURING CODE REVIEW:** Use a simplified notation. Most members of the team preferred `{ location: { region_name, start, end } }` over having these three fields directly at the top level of a variant.

3. **Does variant have allele type?**

The [XD](https://xd.adobe.com/view/2e253ea8-6bd8-4efa-ad39-dc65f9eb01bd-7b76/screen/802e46d2-1597-4821-ad78-20b392e5d925/) shows the allele type string under the variant name in the variant (left) column; but the VEP output produces allele types on per-allele level.

**OUTCOME:**  Could not reach a clear decision on this one. Andrea wants to display allele type at the variant level. I am leaving this field in the variant model for now.

### Jira ticket
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2588