### PR TITLE
Updates to VEP results schema in the spec

### DIFF
--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -50,7 +50,9 @@ components:
         predicted_molecular_consequences:
           type: array
           items:
-            $ref: '#/components/schemas/PredictedTranscriptConsequence'
+            anyOf:
+              - $ref: '#/components/schemas/PredictedTranscriptConsequence'
+              - $ref: '#/components/schemas/PredictedIntergenicConsequence'
     PaginationMetadata:
       type: object
       required:
@@ -64,6 +66,20 @@ components:
           type: number
         total:
           type: number
+    PredictedIntergenicConsequence:
+      type: object
+      required:
+        - feature_type
+        - consequences
+      properties:
+        feature_type:
+          nullable: true
+          description: The value of this field is always null. The presence of null in this field will serve as a marker that this is a consequence of an intergenic variant.
+        consequences:
+          type: array
+          items:
+            type: string
+          description: The only expected member of this array will be the string 'intergenic_variant'
     PredictedTranscriptConsequence:
       type: object
       required:

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -130,7 +130,7 @@ components:
       required:
         - name
         - allele_type
-        - slice
+        - location
         - reference_allele
         - alternative_alleles
       properties:
@@ -138,6 +138,8 @@ components:
           type: string
           nullable: true
           description: User's name for the variant; optional
+        allele_type:
+          type: string
         location:
           type: object
           properties:

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -70,6 +70,7 @@ components:
         - feature_type
         - stable_id
         - gene_stable_id
+        - gene_symbol
         - biotype
         - is_canonical
         - consequences
@@ -85,6 +86,9 @@ components:
         gene_stable_id:
           type: string
           description: gene stable id, versioned
+        gene_symbol:
+          type: string
+          nullable: true
         biotype:
           type: string
         is_canonical:


### PR DESCRIPTION
- Added gene symbol to `PredictedTranscriptConsequence`
- Added `PredictedIntergenicConsequence` schema

`PredictedIntergenicConsequence` is a sort of a hack. It is a way to express that a given variant is classified as an intergenic variant, and that there are no specific features, such as genes or regulatory features, associated with it. The VEP tool will save this information in the VCF file as a variant consequence. The Variation team fully acknowledge that, technically, this isn't a consequence, in the sense that transcript consequences or regulatory consequences are; but this is what we've got.

The payload for a predicted intergenic consequence will be:

```
{
  feature_type: null,
  consequences: ["intergenic_variant"]
}
```

`feature_type: null` will help client identify this type of consequences; and the array type of the `consequences` field is kept for consistency with the schema of predicted transcript consequences.