### PR TITLE
Update api spec

### DIFF
--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -30,7 +30,6 @@ paths:
                   type: string
                 input_text:
                   type: string
-                  nullable: true
                 input_file:
                   type: string
                   format: binary
@@ -44,7 +43,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VepResultsResponse'
+                $ref: '#/components/schemas/VepFormSubmissionCreatedResponse'
   /api/tools/vep/submissions/{id}/results:
     get:
       description: Returns results of VEP analysis

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -28,15 +28,13 @@ paths:
               properties:
                 genome_id:
                   type: string
-                input_text:
-                  type: string
                 input_file:
                   type: string
                   format: binary
                 parameters:
                   type: string
                   description: |
-                    Stringified JSON of parameters, such as { "transcript_set": string, "gene_symbol": true, "biotype": true }
+                    Stringified JSON of parameters, such as '{"transcript_set":"blah","symbol":true,"biotype":true}'
       responses:
         '200':
           description: Successful operaiton.
@@ -146,7 +144,7 @@ components:
         - feature_type
         - stable_id
         - gene_stable_id
-        - gene_symbol
+        - symbol
         - biotype
         - is_canonical
         - consequences
@@ -162,7 +160,7 @@ components:
         gene_stable_id:
           type: string
           description: gene stable id, versioned
-        gene_symbol:
+        symbol:
           type: string
           nullable: true
         biotype:

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -3,6 +3,48 @@ info:
   title: Tools api
   version: 0.0.1
 paths:
+  /vep/config:
+    get:
+      parameters:
+        - name: genome_id
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VepConfigResponse'
+  /vep/submission:
+    post:
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                genome_id:
+                  type: string
+                input_text:
+                  type: string
+                  nullable: true
+                input_file:
+                  type: string
+                  format: binary
+                parameters:
+                  type: string
+                  description: |
+                    Stringified JSON of parameters, such as { "transcript_set": string, "gene_symbol": true, "biotype": true }
+      responses:
+        '200':
+          description: Successful operaiton.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VepResultsResponse'
   /api/tools/vep/submissions/{id}/results:
     get:
       description: Returns results of VEP analysis
@@ -53,6 +95,25 @@ components:
             anyOf:
               - $ref: '#/components/schemas/PredictedTranscriptConsequence'
               - $ref: '#/components/schemas/PredictedIntergenicConsequence'
+    BooleanConfigOption:
+      type: object
+      required:
+        - label
+        - description
+        - type
+        - default_value
+      properties:
+        label:
+          type: string
+        description:
+          type: string
+          nullable: true
+        type:
+          type: string
+          enum:
+            - boolean
+        default_value:
+          type: boolean
     PaginationMetadata:
       type: object
       required:
@@ -125,6 +186,38 @@ components:
       properties:
         allele_sequence:
           type: string
+    SelectConfigOption:
+      type: object
+      required:
+        - label
+        - description
+        - type
+        - options
+        - default_value
+      properties:
+        label:
+          type: string
+        description:
+          type: string
+          nullable: true
+        type:
+          type: string
+          enum:
+            - select
+        options:
+          type: array
+          items:
+            type: object
+            properties:
+              label:
+                type: string
+              value:
+                type: string
+            required:
+              - label
+              - value
+        default_value:
+          type: string
     Variant:
       type: object
       required:
@@ -159,6 +252,17 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/AlternativeVariantAllele'
+    VepConfigResponse:
+      type: object
+      required:
+        - parameters
+      properties:
+        parameters:
+          type: array
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/BooleanConfigOption'
+              - $ref: '#/components/schemas/SelectConfigOption'
     VepResultsResponse:
       type: object
       required:
@@ -176,3 +280,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Variant'
+    VepFormSubmissionCreatedResponse:
+      type: object
+      required:
+        - submission_id
+      properties:
+        submission_id:
+          type: string


### PR DESCRIPTION
This PR contains updates to the API spec to describe the VEP form config endpoint, and the the VEP form submission payload (see jiras [ENSWBSITES-2602](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2602) and [ENSWBSITES-2603](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2603)).

## Points for discussion

### The config endpoint
The funny thing about this endpoint is that, after we have excluded practically everything that is genome-specific from the scope of the phase 1 of VEP, there is very little point left in this endpoint. However:

- Adding it shows us how we expect to grow the form further
- Adding it might provide the client with the information about the transcript set that it otherwise won't have.

Here's what an example config payload might look like:

```json
{
  "parameters": {
    "transcript_set": {
      "label": "Transcript set",
      "description": null,
      "type": "select",
      "options": [
        {
          "label": "GENCODE",
          "value": "gencode_comprehensive"
        }
      ],
      "default_value": "gencode_comprehensive"
    },
    "symbol": {
      "label": "Gene symbol",
      "description": null,
      "type": "boolean",
      "default_value": true
    },
    "biotype": {
      "label": "Transcript biotype",
      "description": null,
      "type": "boolean",
      "default_value": true
    }
  }
}
```

The parameters are defined in the following way:
- The key is the name of the parameter that will be the sent back to the tools api in the form submission payload
- The value is a json object that describes what kind of a parameter this is (so far, we have booleans/checkboxes, and selects)

A question we may want to ask ourselves here is whether the keys of the parameters should be named in exactly the same way as the names of the arguments in the VEP ini file. If yes, then `gene_symbol` should be named `symbol`. The `transcript_set` parameter has no direct equivalent in the VEP ini file; and in the future, will probably need to be mapped to an appropriate gff file.

The most interesting part about this payload is the `transcript_set` parameter. It was decided that for Phase 1, there will only be one transcript set per genome; however, it was also suggested that some genomes (e.g. human and mouse) may have several transcript sets (e.g. GENCODE comprehensive vs GENCODE primary); and that in the future, users should be able to choose one or the other.

### The form submission endpoint

- If the payload includes a file, it seems that the only option available to us is multipart form data
- The question is then whether each of the form parameters should go into its own named field of the multipart form data; or it is more practical to have something like a `parameters` field that takes a stringified json of all the parameters of the VEP form (the submitted PR uses this latter approach).
  - Note: An [example in Swagger documentation](https://swagger.io/docs/specification/describing-request-body/multipart-requests/) suggests that a field in multipart form data can be an object? Something to investigate.
- Each of the parameters will be named with a key that is read from the config, and have a value described by the config.
- Currently, the schema has two fields, only one of which can be filled: `input_text`, or `input_file`
  - Not sure if there's any benefit in standardising on a single field (i.e. transform user input text into a plain-text file).
  - Don't know how to represent the empty fields in this schema

### Decisions after code review:
- Pass parameters as a stringified json rather than a bunch of independent multipart/form-data fields
  - Represent boolean values with json booleans rather than with strings such as "1" or "0"
- Unify `input_text` and `input_file` fields into a single `input_file` field
- Use the name `symbol` for a parameter instead of `gene_symbol` (`symbol` is closer to the name of the option that the VEP tool eventually accepts)