### PR TITLE
Fix routing for VEP

### DIFF
--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -3,7 +3,7 @@ info:
   title: Tools api
   version: 0.0.1
 paths:
-  /vep/config:
+  /api/tools/vep/config:
     get:
       parameters:
         - name: genome_id
@@ -18,7 +18,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/VepConfigResponse'
-  /vep/submission:
+  /api/tools/vep/submissions:
     post:
       requestBody:
         content:

--- a/app/blast/blast.py
+++ b/app/blast/blast.py
@@ -1,6 +1,6 @@
 from contextlib import asynccontextmanager
 from urllib import response
-from fastapi import FastAPI, Response
+from fastapi import FastAPI, Response, APIRouter
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
@@ -29,7 +29,6 @@ from core.config import BLAST_CONFIG
 
 
 app = FastAPI()
-
 
 # Override response for input payload validation error
 @app.exception_handler(RequestValidationError)
@@ -74,8 +73,8 @@ class DbType(str, Enum):
 
 
 class BlastParams(BaseModel, extra='allow'):
-    email: str | None = "blast2020@ebi.ac.uk"
-    title: str | None = ""
+    email: str = "blast2020@ebi.ac.uk"
+    title: str = ""
     program: Program
     database: DbType
 

--- a/app/main.py
+++ b/app/main.py
@@ -29,7 +29,7 @@ def get_application() -> FastAPI:
         CORSMiddleware,
         allow_origins=ALLOWED_HOSTS or ["*"],
         allow_credentials=True,
-        allow_methods=["GET"],
+        allow_methods=["POST", "GET"],
         allow_headers=["*"],
     )
 

--- a/app/main.py
+++ b/app/main.py
@@ -19,7 +19,7 @@ from fastapi import FastAPI
 from starlette.middleware.cors import CORSMiddleware
 
 from blast.blast import app as blast_app
-from vep.routes import router
+from vep.routes import router as vep_router
 from core.config import API_PREFIX, ALLOWED_HOSTS, VERSION, PROJECT_NAME, DEBUG
 
 def get_application() -> FastAPI:
@@ -33,10 +33,10 @@ def get_application() -> FastAPI:
         allow_headers=["*"],
     )
 
-    application.include_router(router, prefix=API_PREFIX)
+    application.include_router(vep_router, prefix=API_PREFIX)
 
     return application
 
 
 app = get_application()
-app.mount("/blast", blast_app)
+app.mount("/api/tools/blast", blast_app)

--- a/app/tests/test_blast.py
+++ b/app/tests/test_blast.py
@@ -9,7 +9,7 @@ def test_read_config():
 	with TestClient(app) as client: #include @startup hook
 		with open('/data/blast_config.json') as f:
 			config = json.load(f)
-		response = client.get('/blast/config')
+		response = client.get('/api/tools/blast/config')
 		assert response.status_code == 200
 		assert response.json() == config
 
@@ -30,7 +30,7 @@ def test_get_db_path(blast_payload):
 # Test single BLAST job submission with a valid payload
 def test_blast_job(blast_payload):
 	with TestClient(app) as client:
-		response = client.post('/blast/job', json=blast_payload)
+		response = client.post('/api/tools/blast/job', json=blast_payload)
 		assert response.status_code == 200
 		resp = response.json()
 		assert 'submission_id' in resp
@@ -48,7 +48,7 @@ def test_blast_jobs(blast_payload):
 	with TestClient(app) as client:
 		blast_payload['genome_ids'].append(blast_payload['genome_ids'][0])
 		blast_payload['query_sequences'].append({'id': 2, 'value': 'MPIGSKERPTFKTRCNKADLGPI'})
-		response = client.post('/blast/job', json=blast_payload)
+		response = client.post('/api/tools/blast/job', json=blast_payload)
 		assert response.status_code == 200
 		resp = response.json()
 		assert 'submission_id' in resp
@@ -63,7 +63,7 @@ def test_blast_jobs(blast_payload):
 def test_blast_job_data_error(blast_payload):
 	with TestClient(app) as client:
 		del blast_payload['query_sequences']
-		response = client.post('/blast/job', json=blast_payload)
+		response = client.post('/api/tools/blast/job', json=blast_payload)
 		assert response.status_code == 422
 		resp = response.json()
 		assert 'error' in resp
@@ -74,7 +74,7 @@ def test_blast_job_jd_error(blast_payload):
 	with TestClient(app) as client:
 		# 'stype'='dna' is incompatible with 'program'='blastp'
 		blast_payload['parameters']['stype'] = 'dna'
-		response = client.post('/blast/job', json=blast_payload)
+		response = client.post('/api/tools/blast/job', json=blast_payload)
 		assert response.status_code == 200
 		resp = response.json()
 		assert 'jobs' in resp
@@ -87,7 +87,7 @@ def test_blast_job_jd_error(blast_payload):
 # Test BLAST job status endpoint
 def test_blast_job_status():
 	with TestClient(app) as client:
-		response = client.get('/blast/jobs/status/ncbiblast_ensembl-12345')
+		response = client.get('/api/tools/blast/jobs/status/ncbiblast_ensembl-12345')
 		assert response.status_code == 200
 		assert 'status' in response.json()
 
@@ -96,7 +96,7 @@ def test_blast_job_status():
 def test_blast_job_statuses():
 	with TestClient(app) as client:
 		job_ids = {'job_ids': ['ncbiblast-1234', 'ncbiblast-5678']}
-		response = client.post('/blast/jobs/status', json=job_ids)
+		response = client.post('/api/tools/blast/jobs/status', json=job_ids)
 		assert response.status_code == 200
 		resp = response.json()
 		assert 'statuses' in resp
@@ -107,13 +107,13 @@ def test_blast_job_statuses():
 # Test JD proxy error response
 def test_blast_proxy_error():
 	with TestClient(app) as client:
-		response = client.get('/blast/jobs/na/na')
+		response = client.get('/api/tools/blast/jobs/na/na')
 		assert response.status_code == 404
 		assert 'error' in response.json()
 
 # Test invalid endpoint error response
 def test_404_error():
 	with TestClient(app) as client:
-		response = client.get('/blast/invalid_path')
+		response = client.get('/api/tools/blast/invalid_path')
 		assert response.status_code == 404
 		assert response.json() == {'error': 'Invalid endpoint'}


### PR DESCRIPTION
### Description
With the addition of the VEP it is now have 2 tools to handle blast/vep. 
This introduced the inconsistency in the way the route to /blast and /vep were being handled in production and development. 
This PR makes it consistent across environment and tools.



### Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2644

### Review App URL(s) 
This can be checked on dev-2020.ensembl.org

### Knowledge Base
<!--
_If the PR introduces new concept, then provide link(s) to the Knowledge base ( Documentation, Blog etc )_
-->

### Example(s)
<!--
_Any details that will help reviewers to review the PR, such as  (but not limited to ) expected request/response, instruction for viewing the changes via the web client, or any other relevant information._
-->

### Checklist

- [ ] Black formatting
- [x] Tests

### Dependencies 
The ingress rules now needs to be updated by removing the rewrite.