### PR TITLE
Add spec for VEP submission status endpoint to the api spec

### DIFF
--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -305,7 +305,7 @@ components:
       properties:
         message:
           type: string
-          description: A message that says, "A submission with id <id> was not found"
+          example: A submission with id 1234567 was not found
     VepSubmissionStatusResponse:
       type: object
       required:

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -42,6 +42,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/VepFormSubmissionCreatedResponse'
+  /api/tools/vep/submissions/{id}/status:
+    get:
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VepSubmissionStatusResponse'
   /api/tools/vep/submissions/{id}/results:
     get:
       description: Returns results of VEP analysis
@@ -277,6 +292,27 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Variant'
+    VepSubmissionStatusResponse:
+      type: object
+      required:
+        - submission_id
+        - status
+      properties:
+        submission_id:
+          type: string
+        status:
+          type: string
+          description: >
+            The possible statuses for a VEP submission are based on the list of documented statuses of Seqera workflows
+            (see https://github.com/seqeralabs/tower-cli/blob/50dd04dd806acf8461dfc9b286faec7e874aec15/USAGE.md?plain=1#L254-L259),
+            except for the 'UNKNOWN' status, which is listed in Seqera docs without explanation how a workflow can get into that status.
+            If the tools api receives 'UNKNOWN' status from the Seqera platform, interpret it the same as FAILED.
+          enum:
+            - SUBMITTED
+            - RUNNING
+            - SUCCEEDED
+            - FAILED
+            - CANCELLED
     VepFormSubmissionCreatedResponse:
       type: object
       required:

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -57,6 +57,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/VepSubmissionStatusResponse'
+        '404':
+          description: Submission not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VepSubmissionNotFoundResponse'
   /api/tools/vep/submissions/{id}/results:
     get:
       description: Returns results of VEP analysis
@@ -292,6 +298,14 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Variant'
+    VepSubmissionNotFoundResponse:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+          description: A message that says, "A submission with id <id> was not found"
     VepSubmissionStatusResponse:
       type: object
       required:
@@ -306,7 +320,7 @@ components:
             The possible statuses for a VEP submission are based on the list of documented statuses of Seqera workflows
             (see https://github.com/seqeralabs/tower-cli/blob/50dd04dd806acf8461dfc9b286faec7e874aec15/USAGE.md?plain=1#L254-L259),
             except for the 'UNKNOWN' status, which is listed in Seqera docs without explanation how a workflow can get into that status.
-            If the tools api receives 'UNKNOWN' status from the Seqera platform, interpret it the same as FAILED.
+            If the tools api receives the 'UNKNOWN' status from the Seqera platform, the status reported to the client is FAILED.
           enum:
             - SUBMITTED
             - RUNNING


### PR DESCRIPTION
## Description
Added specifications for VEP submission status endpoint to the OpenAPI spec.

### Knowledge base
See Seqera's [openAPI spec](https://cloud.seqera.io/openapi/index.html#get-/workflow/-workflowId-) or [code documentation](https://github.com/seqeralabs/tower-cli/blob/50dd04dd806acf8461dfc9b286faec7e874aec15/USAGE.md?plain=1#L254-L259) for the list of possible values that can come from Seqera. The strings reported by Seqera are all upper-cased.

### NOTE
Among the possible statuses that can be returned by Seqera is `UNKNOWN`. I have no idea when it may occur (docs don't explain anything other than that it is an "indeterminate status"), or what to do with it on the client side. I suggest that if tools api ever encounters it, it should consider the job as failed, and respond to the web client with the `FAILED` status.

### Example json response

```json
{
  "submission_id": "string",
  "status": "SUBMITTED"
}
```


## Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2648