### PR TITLE
Update to vcf_results to support vcf.gz files

### DIFF
--- a/app/vep/utils/vcf_results.py
+++ b/app/vep/utils/vcf_results.py
@@ -52,9 +52,8 @@ def _set_allele_type(alt_one_bp: bool, ref_one_bp: bool, ref_alt_equal_bp: bool)
 
 
 def _get_prediction_index_map(
-                        csq_header: str,
-                        target_columns: List[str] = None
-                    ) -> Dict:
+    csq_header: str, target_columns: List[str] = None
+) -> Dict:
     """Creates a dictionary of column indexes based
     on the CSQ info description"""
     if not target_columns:
@@ -102,7 +101,7 @@ def _get_alt_allele_details(
         if len(cons) == 0:
             cons = []
         else:
-            cons = cons.split('&')
+            cons = cons.split("&")
         if csq_values[index_map["Feature_type"]] == "Transcript":
             is_cononical = (
                 _get_csq_value(csq_values, "CANONICAL", "NO", index_map) == "YES"
@@ -163,7 +162,9 @@ def get_results_from_stream(
     vcf_records = vcfpy.Reader.from_stream(vcf_stream)
     return _get_results_from_vcfpy(page_size, page, vcf_records)
 
-def _get_results_from_vcfpy(page_size: int, page: int, vcf_records: vcfpy.Reader
+
+def _get_results_from_vcfpy(
+    page_size: int, page: int, vcf_records: vcfpy.Reader
 ) -> model.VepResultsResponse:
     """Generates a page of VCF data in the format described in
     APISpecification.yaml for a given VCFPY reader"""
@@ -216,7 +217,9 @@ def _get_results_from_vcfpy(page_size: int, page: int, vcf_records: vcfpy.Reader
             model.Variant(
                 name=";".join(record.ID) if len(record.ID) > 0 else ".",
                 location=location,
-                reference_allele=model.ReferenceVariantAllele(allele_sequence=record.REF),
+                reference_allele=model.ReferenceVariantAllele(
+                    allele_sequence=record.REF
+                ),
                 alternative_alleles=alt_alleles,
                 allele_type=_set_allele_type(
                     longest_alt < 2, ref_len < 2, longest_alt == ref_len
@@ -236,10 +239,8 @@ def _get_results_from_vcfpy(page_size: int, page: int, vcf_records: vcfpy.Reader
     return model.VepResultsResponse(
         metadata=model.Metadata(
             pagination=model.PaginationMetadata(
-                page=page,
-                per_page=page_size,
-                total=total
+                page=page, per_page=page_size, total=total
             )
         ),
-        variants=variants
+        variants=variants,
     )


### PR DESCRIPTION
### Description
Update to vcf_results.get_results_from_path to support vcf.gz files

### Related JIRA Issue(s)
[ENSWBSITES-2704](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2704)

### Review App URL(s) 
N/A

### Knowledge Base
This update also resolves a regression introduced during the restructuring of the repo. Unit tests for vcf will now run

### Example(s)
An easy way to test this change is to remove the skip from `test_get_results_with_file_and_dump` and update the `vcf_path` to a local file. This will load in the file and create a json dump of the expected page. Test expects a full page of 100 variants for page 2 so if your test file does not include >300 variants you will need to change this `assert`

### Checklist

- [x] Black formatting
- [x] Tests

### Dependencies 

If you get any errors about headers like `length` make sure you are using `git+https://github.com/likhitha-surapaneni/vcfpy@header-fix` for vcfpy