### PR TITLE
Fix download path

### DIFF
--- a/app/vep/vep_resources.py
+++ b/app/vep/vep_resources.py
@@ -106,7 +106,7 @@ async def download_results(request: Request, submission_id: str):
         if submission_status.status == "SUCCEEDED":
             input_vcf_file = workflow_status["workflow"]["params"]["vcf"]
             input_vcf_path = FilePath(input_vcf_file)
-            results_file_path = input_vcf_path.with_name("_VEP").with_suffix(".vcf.gz")
+            results_file_path = input_vcf_path.with_name(input_vcf_path.stem + "_VEP").with_suffix(".vcf.gz")
             return FileResponse(
                 results_file_path,
                 media_type="application/gzip",

--- a/app/vep/vep_resources.py
+++ b/app/vep/vep_resources.py
@@ -101,7 +101,7 @@ async def download_results(request: Request, submission_id: str):
     try:
         workflow_status = await get_workflow_status(submission_id)
         submission_status = PipelineStatus(
-            submission_id=submission_id, status=workflow_status["workflow"]["status"]
+            submission_id=submission_id, status=workflow_status
         )
         if submission_status.status == "SUCCEEDED":
             input_vcf_file = workflow_status["workflow"]["params"]["vcf"]


### PR DESCRIPTION
### Description
The vcf output file name is not being constructed correctly.
Currently, The output file name being constructed is 
```
_VEP.vcf.gz
```
The correct name should be
```
<INPUT_FILE_NAME>_VEP.vcf.gz
```
This PR fixes this problem.

### Related JIRA Issue(s)
<!--_Please provide the URL(s) for any JIRA issues related to this PR._-->

### Review App URL(s) 
http://__BRANCH_NAME_HERE__.review.ensembl.org

### Knowledge Base
<!--
_If the PR introduces new concept, then provide link(s) to the Knowledge base ( Documentation, Blog etc )_
-->

### Example(s)
```
>>> from pydantic import DirectoryPath, FilePath
>>> fps = '/nfs/public/rw/enswbsites/dev/vep/tmpjn5_lgkx/vep-input.vcf'
>>> fp = FilePath(fps)
>>> fp
PosixPath('/nfs/public/rw/enswbsites/dev/vep/tmpjn5_lgkx/vep-input.vcf')
>>> fp.with_name("_VEP")
PosixPath('/nfs/public/rw/enswbsites/dev/vep/tmpjn5_lgkx/_VEP')
>>> fp
PosixPath('/nfs/public/rw/enswbsites/dev/vep/tmpjn5_lgkx/vep-input.vcf')
>>> rfp  = fp.with_name("_VEP")
>>> rfp
PosixPath('/nfs/public/rw/enswbsites/dev/vep/tmpjn5_lgkx/_VEP')
```

### Checklist

- [ ] Black formatting
- [ ] Tests

### Dependencies 
<!--
_Does it need anything else before the PR gets merged. May be data update, k8s config update, PR in another repository_
-->