### PR TITLE
Handle missing vcf out file

### DIFF
--- a/app/vep/vep_resources.py
+++ b/app/vep/vep_resources.py
@@ -105,7 +105,8 @@ async def vep_status(request: Request, submission_id: str):
 
 def get_vep_results_file_path(input_vcf_file):
     input_vcf_path = FilePath(input_vcf_file)
-    return input_vcf_path.with_name(input_vcf_path.stem + "_VEP").with_suffix(".vcf.gz")
+    vep_results_file = input_vcf_path.with_name(input_vcf_path.stem + "_VEP").with_suffix(".vcf.gz")
+    return vep_results_file
 
 
 @router.get("/submissions/{submission_id}/download", name="download_results")
@@ -118,8 +119,15 @@ async def download_results(request: Request, submission_id: str):
         if submission_status.status == VepStatus.succeeded:
             input_vcf_file = workflow_status["workflow"]["params"]["vcf"]
             results_file_path = get_vep_results_file_path(input_vcf_file)
-
-            return FileResponse(results_file_path, media_type="application/gzip", filename=results_file_path.name)
+            if results_file_path.exists():
+                return FileResponse(results_file_path, media_type="application/gzip", filename=results_file_path.name)
+            else:
+                response_msg = {
+                    "details": f"A submission with id {submission_id} succeeded but could not find output file",
+                }
+                return JSONResponse(
+                    content=response_msg, status_code=status.HTTP_404_NOT_FOUND
+                )
         else:
             response_msg = {
                 "details": f"A submission with id {submission_id} is not yet finished",
@@ -152,7 +160,15 @@ async def fetch_results(request: Request, submission_id: str, page: int, per_pag
         if submission_status.status == VepStatus.succeeded:
             input_vcf_file = workflow_status["workflow"]["params"]["vcf"]
             results_file_path = get_vep_results_file_path(input_vcf_file)
-            return get_results_from_path(vcf_path = results_file_path, page=page, page_size = per_page)
+            if results_file_path.exists():
+                return get_results_from_path(vcf_path = results_file_path, page=page, page_size = per_page)
+            else:
+                response_msg = {
+                    "details": f"A submission with id {submission_id} succeeded but could not find output file",
+                }
+                return JSONResponse(
+                    content=response_msg, status_code=status.HTTP_404_NOT_FOUND
+                )
 
     except HTTPError as http_error:
         if http_error.response.status_code in [403,400]:


### PR DESCRIPTION
### Description
Handle missing VEP output file.

### Related JIRA Issue(s)
<!--_Please provide the URL(s) for any JIRA issues related to this PR._-->

### Review App URL(s) 


### Knowledge Base
<!--
_If the PR introduces new concept, then provide link(s) to the Knowledge base ( Documentation, Blog etc )_
-->

### Example(s)
Job succeeded
```
curl 'https://staging-2020.ensembl.org/api/tools/vep/submissions/5hHcTMmGQHzNjd/status' | jq                       
{
  "submission_id": "5hHcTMmGQHzNjd",
  "status": "SUCCEEDED"
}
```

`/results` and `/download` endpoint fails
```
curl 'https://staging-2020.ensembl.org/api/tools/vep/submissions/5hHcTMmGQHzNjd/results?page=0&per_page=10'
{
  "status_code": 500,
  "details": "Internal Server Error"
}
```
Caused by missing out put VCF file interesting_VEP.vcf.gz even after status is succeeded

```
ls -l <OUT-DIR>vep/tmp4x0c9255/
total 160
-rw-r--r-- 1 6630 1135   189 Aug 15 16:28 config.ini
-rw-r--r-- 1 6630 1135 22182 Aug 15 16:28 interesting.vcf
```
After fix
```
curl 'http://localhost:8013/api/tools/vep/submissions/5hHcTMmGQHzNjd/results?page=0&per_page=10' | jq       
{
  "details": "A submission with id 5hHcTMmGQHzNjd succeeded but could not find output file"
}

```
### Checklist

- [x] Black formatting
- [x] Tests

### Dependencies 
<!--
_Does it need anything else before the PR gets merged. May be data update, k8s config update, PR in another repository_
-->