### PR TITLE
VEP: update logic for generating alt alleles in the vcf to json script

### DIFF
--- a/app/vep/utils/vcf_results.py
+++ b/app/vep/utils/vcf_results.py
@@ -218,8 +218,8 @@ def _get_results_from_vcfpy(
         # from competting vcf module
         location = model.Location(
             region_name=record.CHROM,
-            start=record.begin,
-            end=record.end if record.end else record.begin + ref_len,
+            start=record.POS,
+            end=record.POS + ref_len,
         )
         longest_alt = len(max((a.value for a in record.ALT), key=len))
 


### PR DESCRIPTION
## Description
### Bug
In response from https://staging-2020.ensembl.org/api/tools/vep/submissions/5UvdiTnQBeK0gU/results?page=1&per_page=100, the allele_type of alternative alleles is spelled incorrectly ("INS" rather than "insertion"); and the `predicted_molecular_consequences` array is empty, which should never happen:

```
{
  "metadata": {
    "pagination": {
      "page": 1,
      "per_page": 100,
      "total": 1
    }
  },
  "variants": [
    {
      "name": "rs1405511870",
      "allele_type": "insertion",
      "location": {
        "region_name": "1",
        "start": 924510,
        "end": 924511
      },
      "reference_allele": {
        "allele_sequence": "C"
      },
      "alternative_alleles": [
        {
          "allele_sequence": "CGCTGCC",
          "allele_type": "INS",
          "representative_population_allele_frequency": null,
          "predicted_molecular_consequences": []
        }
      ]
    }
  ]
}
```

See file from which this json was generated ([Slack link](https://genomes-ebi.slack.com/archives/G0104HU9R1C/p1723846118817199))

### Cause
The code was comparing sequences from the `ALT` field of the vcf file with allele sequences of the `CSQ` data (see vcf file). However, for some allele types, such as insertions, indels, and probably deletions, these strings may differ because of different conventions regarding the inclusion of the "anchor" nucleotide into the allele sequence.