### PR TITLE
Trust environment

### DIFF
--- a/app/blast/blast.py
+++ b/app/blast/blast.py
@@ -14,7 +14,7 @@ import json
 import re
 import os
 
-from core.config import BLAST_CONFIG
+from core.config import BLAST_CONFIG, TRUST_ENV
 
 
 # @asynccontextmanager
@@ -114,10 +114,11 @@ blast_url = os.environ.get(
 )
 
 
+
 async def run_blast(
     query: dict, blast_payload: dict, genome_id: str, db_type: str
 ) -> dict:
-    app.client_session = ClientSession()
+    app.client_session = ClientSession(trust_env=TRUST_ENV)
     blast_payload["sequence"] = query["value"]
     blast_payload["database"] = get_db_path(genome_id, db_type)
     url = f"{blast_url}/run"
@@ -179,7 +180,7 @@ async def blast_job_statuses(payload: JobIDs) -> dict:
 @app.get("/jobs/{action}/{params:path}")
 async def blast_proxy(action: str, params: str, response: Response = None) -> dict:
     url = f"{blast_url}/{action}/{params}"
-    app.client_session = ClientSession()
+    app.client_session = ClientSession(trust_env=TRUST_ENV)
     async with app.client_session.get(url) as resp:
         if response:
             response.status_code = resp.status  # forward the status code from JD

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -30,6 +30,7 @@ API_PREFIX = "/api/tools"
 
 config = Config(".env")
 DEBUG: bool = config("DEBUG", cast=bool, default=False)
+TRUST_ENV: bool = config("TRUST_ENV", cast=bool, default=True)
 PROJECT_NAME: str = config("PROJECT_NAME", default="Ensembl Web Tools API")
 ALLOWED_HOSTS: list[str] = config(
     "ALLOWED_HOSTS",


### PR DESCRIPTION
### Description
Trust environment when accessing APIs on non standard port. 
WP has given following URL http://test.jd.sdo.ebi.ac.uk:8180/ to run blast. While using this URL for submitting jobs to blast it was not working and was timing out ( in 30s ) and ultimately throwing 500 error. 
This was caused while Tools API ( using aiohttp.ClientSession ) trying to connect to BLAST_URL. This was caused by the BLAST_URL was running on non standard port. 

```
aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host test.jd.sdo.ebi.ac.uk:8180 ssl:default [Connect call failed ('10.49.35.67', 8180)]
```

This PR fixes above problem by introducing TRUST_ENV environment variable which will allow aiohttp.ClientSession to use http_proxy and make an http request.

### Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2749

### Review App URL(s) 
None

### Knowledge Base
Proxy Support
https://docs.aiohttp.org/en/stable/client_advanced.html#proxy-support
ClientSession
https://docs.aiohttp.org/en/stable/client_reference.html

### Example(s)
without trust_env
```
async def ren_blast():
     client_session = ClientSession()
     resp = client_session.get('http://test.jd.sdo.ebi.ac.uk:8180/Tools/services/rest/ncbiblast/result/ncbiblast-R20240909-150728-0832-41579270-np2/out')
     print('response', await resp)
```
Results in 
```
aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host test.jd.sdo.ebi.ac.uk:8180 ssl:default [Connect call failed ('10.49.35.67', 8180)]
```


with trust_env
```
async def ren_blast_trust():
     client_session = ClientSession(trust_env=True)
     resp = client_session.get('http://test.jd.sdo.ebi.ac.uk:8180/Tools/services/rest/ncbiblast/result/ncbiblast-R20240909-150728-0832-41579270-np2/out')
     print('response', await resp)
```
Results in
```
response <ClientResponse(http://test.jd.sdo.ebi.ac.uk:8180/Tools/services/rest/ncbiblast/result/ncbiblast-R20240909-150728-0832-41579270-np2/out) [200 OK]>
<CIMultiDictProxy('Server': 'Apache-Coyote/1.1', 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': 'POST, GET, DELETE, PUT', 'Access-Control-Max-Age': '3600', 'Access-Control-Allow-Headers': 'x-requested-with, origin, content-type, accept', 'Content-Disposition': 'inline;filename=ncbiblast-R20240909-150728-0832-41579270-np2.txt', 'Date': 'Mon, 09 Sep 2024 15:04:25 GMT', 'Content-Type': 'text/plain;charset=UTF-8', 'Content-Length': '6057', 'X-Cache': 'MISS from hh-wwwcache.ebi.ac.uk', 'X-Cache-Lookup': 'MISS from hh-wwwcache.ebi.ac.uk:3128', 'Via': '1.1 hh-wwwcache.ebi.ac.uk (squid)', 'Connection': 'keep-alive')>
```
### Checklist

- [x] Black formatting
- [x] Tests

### Dependencies 
None