### PR TITLE
fix annotation provider details

### DIFF
--- a/app/vep/utils/web_metadata.py
+++ b/app/vep/utils/web_metadata.py
@@ -33,7 +33,7 @@ async def get_genome_metadata(genome_id: str) -> GenomeAnnotationProvider:
             + genome_id
             + "/dataset/genebuild/attributes?"
             + "attribute_names=genebuild.provider_name&"
-            + "attribute_names=genebuild.display_version&"
+            + "attribute_names=genebuild.provider_version&"
             + "attribute_names=genebuild.last_geneset_update"
         )
         response.raise_for_status()

--- a/app/vep/vep_resources.py
+++ b/app/vep/vep_resources.py
@@ -218,12 +218,19 @@ async def get_form_config(request: Request, genome_id: str):
     try:
         attributes = await get_genome_metadata(genome_id)
         annotation_provider_name = attributes.get("genebuild.provider_name")
-        annotation_version = attributes.get("genebuild.display_version")
-        last_updated_date = attributes.get("genebuild.last_geneset_update")
+        annotation_version = attributes.get("genebuild.display_version") or ""
+        last_updated_date = attributes.get("genebuild.last_geneset_update") or ""
+
+        if (annotation_version or last_updated_date):
+            label = f"{annotation_provider_name} {annotation_version or last_updated_date}"
+            value = f"{annotation_provider_name}_{annotation_version or last_updated_date}"
+        else:
+            label = f"{annotation_provider_name}"
+            value = f"{annotation_provider_name}"
 
         options = [{
-            "label": f"{annotation_provider_name} {annotation_version or last_updated_date}",
-            "value": f"{annotation_provider_name}_{annotation_version or last_updated_date}"
+            "label": label,
+            "value": value
         }]
 
         default_option = options[0]

--- a/app/vep/vep_resources.py
+++ b/app/vep/vep_resources.py
@@ -217,9 +217,9 @@ async def fetch_results(request: Request, submission_id: str, page: int, per_pag
 async def get_form_config(request: Request, genome_id: str):
     try:
         attributes = await get_genome_metadata(genome_id)
-        annotation_provider_name = attributes.get("genebuild.provider_name")
-        annotation_version = attributes.get("genebuild.display_version") or ""
-        last_updated_date = attributes.get("genebuild.last_geneset_update") or ""
+        annotation_provider_name = attributes.get("genebuild.provider_name", "")
+        annotation_version = attributes.get("genebuild.provider_version", "")
+        last_updated_date = attributes.get("genebuild.last_geneset_update", "")
 
         if (annotation_version or last_updated_date):
             label = f"{annotation_provider_name} {annotation_version or last_updated_date}"


### PR DESCRIPTION
If `annotation provider version` or `last updated date` is unavailable then update payload accordingly so that it doesnt return "None" to the client