### PR TITLE
Update error messaging in Tools API (VEP)

### DIFF
--- a/app/vep/models/pipeline_model.py
+++ b/app/vep/models/pipeline_model.py
@@ -101,5 +101,7 @@ class PipelineStatus(BaseModel):
     def serialize_status(self, status: str):
         if status == "UNKNOWN":
             status = "FAILED"
-            logging.info(f"Unknown status was returned for submission {self.submission_id}")
+            logging.info(
+                f"Unknown status was returned for submission {self.submission_id}"
+            )
         return status

--- a/app/vep/models/pipeline_model.py
+++ b/app/vep/models/pipeline_model.py
@@ -88,7 +88,6 @@ fasta {self.fasta}
                 ini_file.write(config_ini)
             return ini_file
         except Exception as e:
-            logging.info(e)
             raise RuntimeError("Could not create vep config ini file")
 
 
@@ -102,5 +101,5 @@ class PipelineStatus(BaseModel):
     def serialize_status(self, status: str):
         if status == "UNKNOWN":
             status = "FAILED"
-            logging.info("UNKNOWN STATUS WAS RETURNED HERE")
+            logging.info(f"Unknown status was returned for submission {self.submission_id}")
         return status

--- a/app/vep/models/pipeline_model.py
+++ b/app/vep/models/pipeline_model.py
@@ -1,3 +1,4 @@
+import logging, os
 from pydantic import (
     BaseModel,
     DirectoryPath,
@@ -7,13 +8,13 @@ from pydantic import (
     AliasPath,
     field_serializer,
 )
+from requests import HTTPError
+
 from core.config import (
     NF_COMPUTE_ENV_ID,
     NF_PIPELINE_URL,
 )
 from core.logging import InterceptHandler
-import logging, os
-
 from vep.utils.web_metadata import get_vep_support_location
 
 logging.getLogger().handlers = [InterceptHandler()]
@@ -87,8 +88,10 @@ fasta {self.fasta}
             with open(os.path.join(dir, "config.ini"), "w") as ini_file:
                 ini_file.write(config_ini)
             return ini_file
+        except HTTPError:
+            raise
         except Exception as e:
-            raise RuntimeError("Could not create vep config ini file")
+            raise RuntimeError(f"Could not create VEP config ini file: {e}")
 
 
 class PipelineStatus(BaseModel):

--- a/app/vep/models/pipeline_model.py
+++ b/app/vep/models/pipeline_model.py
@@ -88,8 +88,6 @@ fasta {self.fasta}
             with open(os.path.join(dir, "config.ini"), "w") as ini_file:
                 ini_file.write(config_ini)
             return ini_file
-        except HTTPError:
-            raise
         except Exception as e:
             raise RuntimeError(f"Could not create VEP config ini file: {e}")
 

--- a/app/vep/models/submission_form.py
+++ b/app/vep/models/submission_form.py
@@ -1,10 +1,8 @@
-from pydantic import BaseModel
-
+from pydantic import BaseModel, Field
 
 class DropdownOption(BaseModel):
-    label: str
-    value: str
-
+  label: str
+  value: str
 
 class Dropdown(BaseModel):
     label: str
@@ -13,21 +11,17 @@ class Dropdown(BaseModel):
     options: list[DropdownOption]
     default_value: str
 
-
 class Checkbox(BaseModel):
     label: str
     description: str | None = None
     type: str = "boolean"
     default_value: bool = True
 
-
 class FormConfig(BaseModel):
     transcript_set: Dropdown
     symbol: Checkbox = Checkbox(label="Gene symbol")
     biotype: Checkbox = Checkbox(label="Transcript biotype")
 
-
 class GenomeAnnotationProvider(BaseModel):
-    annotation_provider_name: str
-    annotation_version: str
-    last_geneset_update: str
+  annotation_provider_name: str
+  annotation_version: str

--- a/app/vep/models/submission_form.py
+++ b/app/vep/models/submission_form.py
@@ -1,8 +1,10 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
+
 
 class DropdownOption(BaseModel):
-  label: str
-  value: str
+    label: str
+    value: str
+
 
 class Dropdown(BaseModel):
     label: str
@@ -11,17 +13,21 @@ class Dropdown(BaseModel):
     options: list[DropdownOption]
     default_value: str
 
+
 class Checkbox(BaseModel):
     label: str
     description: str | None = None
     type: str = "boolean"
     default_value: bool = True
 
+
 class FormConfig(BaseModel):
     transcript_set: Dropdown
     symbol: Checkbox = Checkbox(label="Gene symbol")
     biotype: Checkbox = Checkbox(label="Transcript biotype")
 
+
 class GenomeAnnotationProvider(BaseModel):
-  annotation_provider_name: str
-  annotation_version: str
+    annotation_provider_name: str
+    annotation_version: str
+    last_geneset_update: str

--- a/app/vep/models/upload_vcf_files.py
+++ b/app/vep/models/upload_vcf_files.py
@@ -92,6 +92,6 @@ class Streamer:
         except (MaxBodySizeException, ValidationError):
             shutil.rmtree(self.temp_dir)
             raise MaxBodySizeException(MAX_FILE_SIZE)
-        except (Exception, ClientDisconnect):
+        except (ClientDisconnect, Exception):
             shutil.rmtree(self.temp_dir)
             raise

--- a/app/vep/models/upload_vcf_files.py
+++ b/app/vep/models/upload_vcf_files.py
@@ -92,8 +92,6 @@ class Streamer:
         except (MaxBodySizeException, ValidationError):
             shutil.rmtree(self.temp_dir)
             raise MaxBodySizeException(MAX_FILE_SIZE)
-        except (Exception, ClientDisconnect) as e:
-            print(e)
-            logging.info(e)
+        except (Exception, ClientDisconnect):
             shutil.rmtree(self.temp_dir)
-            raise Exception
+            raise

--- a/app/vep/utils/nextflow.py
+++ b/app/vep/utils/nextflow.py
@@ -19,7 +19,25 @@ def launch_workflow(pipeline_params: PipelineParams):
         response.raise_for_status()
         response_json = response.json()
         return response_json["workflowId"]
-    except (requests.HTTPError, requests.ConnectionError, Exception) as e:
+    except KeyError as e:
+        e.args = (
+            f"launch_workflow(): unexpected payload from Seqera: f{response.text}",
+            *e.args,
+        )
+        raise
+    except requests.HTTPError as e:
+        e.args = (
+            "launch_workflow(): error response from Seqera:",
+            *e.args,
+        )
+        raise
+    except (requests.ConnectionError, requests.Timeout) as e:
+        e.args = (
+            "launch_workflow(): network error while connecting to Seqera:",
+            *e.args,
+        )
+        raise
+    except Exception as e:
         e.args = (f"{type(e).__name__} in launch_workflow():", *e.args)
         raise
 
@@ -39,6 +57,24 @@ async def get_workflow_status(submission_id):
         response.raise_for_status()
         response_json = response.json()
         return response_json
-    except (requests.HTTPError, requests.ConnectionError, Exception) as e:
-        e.args = (f"{type(e).__name__} in get_workflow_status():", *e.args)
+    except KeyError as e:
+        e.args = (
+            f"launch_workflow(): unexpected payload from Seqera: f{response.text}",
+            *e.args,
+        )
+        raise
+    except requests.HTTPError as e:
+        e.args = (
+            "launch_workflow(): error response from Seqera:",
+            *e.args,
+        )
+        raise
+    except (requests.ConnectionError, requests.Timeout) as e:
+        e.args = (
+            "launch_workflow(): network error while connecting to Seqera:",
+            *e.args,
+        )
+        raise
+    except Exception as e:
+        e.args = (f"{type(e).__name__} in launch_workflow():", *e.args)
         raise

--- a/app/vep/utils/nextflow.py
+++ b/app/vep/utils/nextflow.py
@@ -1,5 +1,4 @@
 import requests
-import logging
 
 from vep.models.pipeline_model import PipelineParams
 from core.config import NF_TOKEN, SEQERA_API, NF_WORKSPACE_ID

--- a/app/vep/utils/nextflow.py
+++ b/app/vep/utils/nextflow.py
@@ -5,32 +5,40 @@ from core.config import NF_TOKEN, SEQERA_API, NF_WORKSPACE_ID
 
 
 def launch_workflow(pipeline_params: PipelineParams):
-    headers = {
-        "Content-Type": "application/json",
-        "Authorization": f"Bearer {NF_TOKEN}",
-    }
-    params = {"workspaceId": NF_WORKSPACE_ID}
-    SEQERA_WORKFLOW_LAUNCH_URL = SEQERA_API + "/workflow/launch"
-    payload = pipeline_params.model_dump()
-    response = requests.post(
-        SEQERA_WORKFLOW_LAUNCH_URL, params=params, headers=headers, json=payload
-    )
-    response.raise_for_status()
-    response_json = response.json()
-    return response_json["workflowId"]
+    try:
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {NF_TOKEN}",
+        }
+        params = {"workspaceId": NF_WORKSPACE_ID}
+        SEQERA_WORKFLOW_LAUNCH_URL = SEQERA_API + "/workflow/launch"
+        payload = pipeline_params.model_dump()
+        response = requests.post(
+            SEQERA_WORKFLOW_LAUNCH_URL, params=params, headers=headers, json=payload
+        )
+        response.raise_for_status()
+        response_json = response.json()
+        return response_json["workflowId"]
+    except (requests.HTTPError, requests.ConnectionError, Exception) as e:
+        e.args = (f"{type(e).__name__} in launch_workflow():", *e.args)
+        raise
 
 
 async def get_workflow_status(submission_id):
-    _headers = {
-        "Content-Type": "application/json",
-        "Authorization": f"Bearer {NF_TOKEN}",
-    }
-    _seqera_workflow_status_url = f"{SEQERA_API}/workflow/{submission_id}"
-    params = {"workspaceId": NF_WORKSPACE_ID}
-    response = requests.get(
-        _seqera_workflow_status_url, params=params, headers=_headers
-    )
+    try:
+        _headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {NF_TOKEN}",
+        }
+        _seqera_workflow_status_url = f"{SEQERA_API}/workflow/{submission_id}"
+        params = {"workspaceId": NF_WORKSPACE_ID}
+        response = requests.get(
+            _seqera_workflow_status_url, params=params, headers=_headers
+        )
 
-    response.raise_for_status()
-    response_json = response.json()
-    return response_json
+        response.raise_for_status()
+        response_json = response.json()
+        return response_json
+    except (requests.HTTPError, requests.ConnectionError, Exception) as e:
+        e.args = (f"{type(e).__name__} in get_workflow_status():", *e.args)
+        raise

--- a/app/vep/utils/nextflow.py
+++ b/app/vep/utils/nextflow.py
@@ -1,12 +1,8 @@
-import requests, logging
-from loguru import logger
-from requests import HTTPError
+import requests
+import logging
 
-from core.logging import InterceptHandler
-from vep.models.pipeline_model import PipelineParams, PipelineStatus
+from vep.models.pipeline_model import PipelineParams
 from core.config import NF_TOKEN, SEQERA_API, NF_WORKSPACE_ID
-
-logging.getLogger().handlers = [InterceptHandler()]
 
 
 def launch_workflow(pipeline_params: PipelineParams):
@@ -17,37 +13,25 @@ def launch_workflow(pipeline_params: PipelineParams):
     params = {"workspaceId": NF_WORKSPACE_ID}
     SEQERA_WORKFLOW_LAUNCH_URL = SEQERA_API + "/workflow/launch"
     payload = pipeline_params.model_dump()
-    try:
-        response = requests.post(
-            SEQERA_WORKFLOW_LAUNCH_URL, params=params, headers=headers, json=payload
-        )
-        response.raise_for_status()
-        response_json = response.json()
-        return response_json["workflowId"]
-
-    except Exception as e:
-        logging.error("VEP WORKFLOW SUBMISSION ERROR: ", e)
-        raise Exception
+    response = requests.post(
+        SEQERA_WORKFLOW_LAUNCH_URL, params=params, headers=headers, json=payload
+    )
+    response.raise_for_status()
+    response_json = response.json()
+    return response_json["workflowId"]
 
 
 async def get_workflow_status(submission_id):
-    try:
-        _headers = {
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {NF_TOKEN}",
-        }
-        _seqera_workflow_status_url = f"{SEQERA_API}/workflow/{submission_id}"
-        params = {"workspaceId": NF_WORKSPACE_ID}
-        response = requests.get(
-            _seqera_workflow_status_url, params=params, headers=_headers
-        )
+    _headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {NF_TOKEN}",
+    }
+    _seqera_workflow_status_url = f"{SEQERA_API}/workflow/{submission_id}"
+    params = {"workspaceId": NF_WORKSPACE_ID}
+    response = requests.get(
+        _seqera_workflow_status_url, params=params, headers=_headers
+    )
 
-        response.raise_for_status()
-        response_json = response.json()
-        return response_json
-
-    except HTTPError as e:
-        raise e
-    except Exception as e:
-        logging.error("VEP connection error: ", e)
-        raise Exception
+    response.raise_for_status()
+    response_json = response.json()
+    return response_json

--- a/app/vep/utils/web_metadata.py
+++ b/app/vep/utils/web_metadata.py
@@ -5,17 +5,14 @@ from core.config import WEB_METADATA_API, VEP_SUPPORT_PATH
 
 
 def get_vep_support_location(genome_id: str) -> str:
-    try:
-        response = requests.get(
-            WEB_METADATA_API
-            + "genome/"
-            + genome_id
-            + "/dataset/genebuild/attributes?attribute_names=vep.bgz_location"
-        )
-        response.raise_for_status()
-        return VEP_SUPPORT_PATH + response.json()["attributes"].pop()["value"]
-    except Exception as e:
-        raise Exception("Error while fetching support file metadata") from e
+    response = requests.get(
+        WEB_METADATA_API
+        + "genome/"
+        + genome_id
+        + "/dataset/genebuild/attributes?attribute_names=vep.bgz_location"
+    )
+    response.raise_for_status()
+    return VEP_SUPPORT_PATH + response.json()["attributes"].pop()["value"]
 
 
 async def get_genome_metadata(genome_id: str) -> GenomeAnnotationProvider:

--- a/app/vep/utils/web_metadata.py
+++ b/app/vep/utils/web_metadata.py
@@ -1,15 +1,10 @@
-from loguru import logger
 import requests
-from requests import HTTPError
 from vep.models.submission_form import GenomeAnnotationProvider
-import logging
-from core.logging import InterceptHandler
-logging.getLogger().handlers = [InterceptHandler()]
+
 from core.config import WEB_METADATA_API, VEP_SUPPORT_PATH
 
-logging.getLogger().handlers = [InterceptHandler()]
 
-def get_vep_support_location(genome_id:str) -> str:
+def get_vep_support_location(genome_id: str) -> str:
     try:
         response = requests.get(
             WEB_METADATA_API
@@ -19,32 +14,24 @@ def get_vep_support_location(genome_id:str) -> str:
         )
         response.raise_for_status()
         return VEP_SUPPORT_PATH + response.json()["attributes"].pop()["value"]
-    except HTTPError as http_error:
-        logging.error(http_error)
-        raise HTTPError
     except Exception as e:
-        logging.error(e)
+        raise Exception("Error while fetching support file metadata") from e
+
+
 async def get_genome_metadata(genome_id: str) -> GenomeAnnotationProvider:
-    try:
-        response = requests.get(
-            WEB_METADATA_API
-            + "genome/"
-            + genome_id
-            + "/dataset/genebuild/attributes?"
-            + "attribute_names=genebuild.provider_name&"
-            + "attribute_names=genebuild.display_version&"
-            + "attribute_names=genebuild.last_geneset_update"
-        )
-        response.raise_for_status()
-        attributes = {}
-        for attribute in response.json()['attributes']:
-            name = attribute['name']
-            value = attribute['value']
-            attributes[name] = value
-        return attributes
-    except HTTPError as http_error:
-        logging.error(http_error)
-        raise HTTPError
-    except Exception as e:
-        logging.error(e)
-        raise Exception
+    response = requests.get(
+        WEB_METADATA_API
+        + "genome/"
+        + genome_id
+        + "/dataset/genebuild/attributes?"
+        + "attribute_names=genebuild.provider_name&"
+        + "attribute_names=genebuild.display_version&"
+        + "attribute_names=genebuild.last_geneset_update"
+    )
+    response.raise_for_status()
+    attributes = {}
+    for attribute in response.json()["attributes"]:
+        name = attribute["name"]
+        value = attribute["value"]
+        attributes[name] = value
+    return attributes

--- a/app/vep/utils/web_metadata.py
+++ b/app/vep/utils/web_metadata.py
@@ -39,7 +39,7 @@ async def get_genome_metadata(genome_id: str) -> GenomeAnnotationProvider:
             + genome_id
             + "/dataset/genebuild/attributes?"
             + "attribute_names=genebuild.provider_name&"
-            + "attribute_names=genebuild.display_version&"
+            + "attribute_names=genebuild.provider_version&"
             + "attribute_names=genebuild.last_geneset_update"
         )
         response.raise_for_status()

--- a/app/vep/utils/web_metadata.py
+++ b/app/vep/utils/web_metadata.py
@@ -5,30 +5,38 @@ from core.config import WEB_METADATA_API, VEP_SUPPORT_PATH
 
 
 def get_vep_support_location(genome_id: str) -> str:
-    response = requests.get(
-        WEB_METADATA_API
-        + "genome/"
-        + genome_id
-        + "/dataset/genebuild/attributes?attribute_names=vep.bgz_location"
-    )
-    response.raise_for_status()
-    return VEP_SUPPORT_PATH + response.json()["attributes"].pop()["value"]
+    try:
+        response = requests.get(
+            WEB_METADATA_API
+            + "genome/"
+            + genome_id
+            + "/dataset/genebuild/attributes?attribute_names=vep.bgz_location"
+        )
+        response.raise_for_status()
+        return VEP_SUPPORT_PATH + response.json()["attributes"].pop()["value"]
+    except (requests.HTTPError, requests.ConnectionError, Exception) as e:
+        e.args = (f"{type(e).__name__} in get_vep_support_location():", *e.args)
+        raise
 
 
 async def get_genome_metadata(genome_id: str) -> GenomeAnnotationProvider:
-    response = requests.get(
-        WEB_METADATA_API
-        + "genome/"
-        + genome_id
-        + "/dataset/genebuild/attributes?"
-        + "attribute_names=genebuild.provider_name&"
-        + "attribute_names=genebuild.display_version&"
-        + "attribute_names=genebuild.last_geneset_update"
-    )
-    response.raise_for_status()
-    attributes = {}
-    for attribute in response.json()["attributes"]:
-        name = attribute["name"]
-        value = attribute["value"]
-        attributes[name] = value
-    return attributes
+    try:
+        response = requests.get(
+            WEB_METADATA_API
+            + "genome/"
+            + genome_id
+            + "/dataset/genebuild/attributes?"
+            + "attribute_names=genebuild.provider_name&"
+            + "attribute_names=genebuild.display_version&"
+            + "attribute_names=genebuild.last_geneset_update"
+        )
+        response.raise_for_status()
+        attributes = {}
+        for attribute in response.json()["attributes"]:
+            name = attribute["name"]
+            value = attribute["value"]
+            attributes[name] = value
+        return attributes
+    except (requests.HTTPError, requests.ConnectionError, Exception)  as e:
+        e.args = (f"{type(e).__name__} in get_genome_metadata(): ", *e.args)
+        raise

--- a/app/vep/utils/web_metadata.py
+++ b/app/vep/utils/web_metadata.py
@@ -14,7 +14,19 @@ def get_vep_support_location(genome_id: str) -> str:
         )
         response.raise_for_status()
         return VEP_SUPPORT_PATH + response.json()["attributes"].pop()["value"]
-    except (requests.HTTPError, requests.ConnectionError, Exception) as e:
+    except KeyError as e:
+        e.args = (
+            f"get_vep_support_location(): unexpected metadata API payload for f{genome_id}:",
+            *e.args,
+        )
+        raise
+    except requests.HTTPError as e:
+        e.args = (
+            f"get_vep_support_location(): error response from metadata API for f{genome_id}:",
+            *e.args,
+        )
+        raise
+    except Exception as e:
         e.args = (f"{type(e).__name__} in get_vep_support_location():", *e.args)
         raise
 
@@ -37,6 +49,18 @@ async def get_genome_metadata(genome_id: str) -> GenomeAnnotationProvider:
             value = attribute["value"]
             attributes[name] = value
         return attributes
-    except (requests.HTTPError, requests.ConnectionError, Exception)  as e:
-        e.args = (f"{type(e).__name__} in get_genome_metadata(): ", *e.args)
+    except KeyError as e:
+        e.args = (
+            f"get_genome_metadata(): unexpected metadata API payload for f{genome_id}:",
+            *e.args,
+        )
+        raise
+    except requests.HTTPError as e:
+        e.args = (
+            f"get_genome_metadata(): error response from metadata API for f{genome_id}:",
+            *e.args,
+        )
+        raise
+    except Exception as e:
+        e.args = (f"{type(e).__name__} in get_genome_metadata():", *e.args)
         raise

--- a/app/vep/vep_resources.py
+++ b/app/vep/vep_resources.py
@@ -78,11 +78,10 @@ async def submit_vep(request: Request):
         else:
             raise Exception("Failed to upload VEP input files")
     except HTTPError as e:
-        msg = (
-            e.response.json()["message"]
-            if "message" in e.response.json()
-            else e.response.text
-        )
+        try:
+            msg = e.response.json()["message"]
+        except Exception:
+            msg = e.response.text
         logging.error(f"VEP submission error (upstream): {msg}: {e}")
         return response_error_handler(result={"status": e.response.status_code})
     except MaxBodySizeException:
@@ -106,11 +105,10 @@ async def vep_status(request: Request, submission_id: str):
         return JSONResponse(content=submission_status.model_dump())
 
     except HTTPError as e:
-        msg = (
-            e.response.json()["message"]
-            if "message" in e.response.json()
-            else e.response.text
-        )
+        try:
+            msg = e.response.json()["message"]
+        except Exception:
+            msg = e.response.text
         logging.error(f"VEP status error (upstream): {msg}: {e}")
         return response_error_handler(result={"status": e.response.status_code})
     except Exception as e:

--- a/app/vep/vep_resources.py
+++ b/app/vep/vep_resources.py
@@ -83,7 +83,7 @@ async def submit_vep(request: Request):
             if "message" in e.response.json()
             else e.response.text
         )
-        logging.error(f"VEP submission error (upstream): {msg}")
+        logging.error(f"VEP submission error (upstream): {msg}: {e}")
         return response_error_handler(result={"status": e.response.status_code})
     except MaxBodySizeException:
         return response_error_handler(result={"status": 413})
@@ -111,7 +111,7 @@ async def vep_status(request: Request, submission_id: str):
             if "message" in e.response.json()
             else e.response.text
         )
-        logging.error(f"VEP status error (upstream): {msg}")
+        logging.error(f"VEP status error (upstream): {msg}: {e}")
         return response_error_handler(result={"status": e.response.status_code})
     except Exception as e:
         logging.error(f"VEP status error: {e}")
@@ -166,9 +166,11 @@ async def download_results(request: Request, submission_id: str):
             return JSONResponse(
                 content=response_msg, status_code=status.HTTP_404_NOT_FOUND
             )
+        else:
+            logging.error(f"VEP download results error (upstream): {e}")
         return response_error_handler(result={"status": e.response.status_code})
     except Exception as e:
-        logging.error(f"VEP download results error: f{e}")
+        logging.error(f"VEP download results error: {e}")
         return response_error_handler(result={"status": 500})
 
 
@@ -212,6 +214,8 @@ async def fetch_results(request: Request, submission_id: str, page: int, per_pag
             return JSONResponse(
                 content=response_msg, status_code=status.HTTP_404_NOT_FOUND
             )
+        else:
+            logging.error(f"VEP fetch results error (upstream): {e}")
         return response_error_handler(result={"status": e.response.status_code})
     except Exception as e:
         logging.error(f"VEP fetch results error: {e}")

--- a/app/vep/vep_resources.py
+++ b/app/vep/vep_resources.py
@@ -68,7 +68,9 @@ async def submit_vep(request: Request):
             vep_config=ini_file.name,
             outdir=request_streamer.temp_dir,
         )
-        launch_params = LaunchParams(paramsText=vep_job_config_parameters, workDir=request_streamer.temp_dir)
+        launch_params = LaunchParams(
+            paramsText=vep_job_config_parameters, workDir=request_streamer.temp_dir
+        )
         pipeline_params = PipelineParams(launch=launch_params)
         if stream_result:
             workflow_id = launch_workflow(pipeline_params)
@@ -76,11 +78,13 @@ async def submit_vep(request: Request):
         else:
             raise Exception("Failed to upload VEP input files")
     except HTTPError as e:
-        msg = e.response.json()["message"] if "message" in e.response.json() else e.response.text
-        logging.error(f"VEP submission error (upstream): {msg}")
-        return response_error_handler(
-            result={"status": e.response.status_code}
+        msg = (
+            e.response.json()["message"]
+            if "message" in e.response.json()
+            else e.response.text
         )
+        logging.error(f"VEP submission error (upstream): {msg}")
+        return response_error_handler(result={"status": e.response.status_code})
     except MaxBodySizeException:
         return response_error_handler(result={"status": 413})
     except Exception as e:
@@ -95,17 +99,20 @@ async def vep_status(request: Request, submission_id: str):
         submission_status = PipelineStatus(
             submission_id=submission_id, status=workflow_status
         )
-        if(submission_status.status==VepStatus.failed):
+        if submission_status.status == VepStatus.failed:
             logging.error(
-                f"VEP submission f{submission_id} failed: f{workflow_status['workflow']['errorMessage'] or workflow_status['workflow']['errorReport']}")
+                f"VEP submission f{submission_id} failed: f{workflow_status['workflow']['errorMessage'] or workflow_status['workflow']['errorReport']}"
+            )
         return JSONResponse(content=submission_status.model_dump())
 
     except HTTPError as e:
-        msg = (e.response.json()["message"] if "message" in e.response.json() else e.response.text)
-        logging.error(f"VEP status error (upstream): {msg}")
-        return response_error_handler(
-            result={"status": e.response.status_code}
+        msg = (
+            e.response.json()["message"]
+            if "message" in e.response.json()
+            else e.response.text
         )
+        logging.error(f"VEP status error (upstream): {msg}")
+        return response_error_handler(result={"status": e.response.status_code})
     except Exception as e:
         logging.error(f"VEP status error: {e}")
         return response_error_handler(result={"status": 500})
@@ -159,9 +166,7 @@ async def download_results(request: Request, submission_id: str):
             return JSONResponse(
                 content=response_msg, status_code=status.HTTP_404_NOT_FOUND
             )
-        return response_error_handler(
-            result={"status": e.response.status_code}
-        )
+        return response_error_handler(result={"status": e.response.status_code})
     except Exception as e:
         logging.error(f"VEP download results error: f{e}")
         return response_error_handler(result={"status": 500})
@@ -207,12 +212,11 @@ async def fetch_results(request: Request, submission_id: str, page: int, per_pag
             return JSONResponse(
                 content=response_msg, status_code=status.HTTP_404_NOT_FOUND
             )
-        return response_error_handler(
-            result={"status": e.response.status_code}
-        )
+        return response_error_handler(result={"status": e.response.status_code})
     except Exception as e:
         logging.error(f"VEP fetch results error: {e}")
         return response_error_handler(result={"status": 500})
+
 
 @router.get("/form_config/{genome_id}", name="get_form_config")
 async def get_form_config(request: Request, genome_id: str):
@@ -222,22 +226,22 @@ async def get_form_config(request: Request, genome_id: str):
         annotation_version = attributes.get("genebuild.display_version")
         last_updated_date = attributes.get("genebuild.last_geneset_update")
 
-        options = [{
-            "label": f"{annotation_provider_name} {annotation_version or last_updated_date}",
-            "value": f"{annotation_provider_name}_{annotation_version or last_updated_date}"
-        }]
+        options = [
+            {
+                "label": f"{annotation_provider_name} {annotation_version or last_updated_date}",
+                "value": f"{annotation_provider_name}_{annotation_version or last_updated_date}",
+            }
+        ]
 
         default_option = options[0]
         transcript_set = Dropdown(
             label="Transcript set",
             options=options,
-            default_value= default_option["value"]
+            default_value=default_option["value"],
         )
 
-        form_config = FormConfig(
-            transcript_set = transcript_set
-        )
-        return { "parameters": form_config }
+        form_config = FormConfig(transcript_set=transcript_set)
+        return {"parameters": form_config}
 
     except HTTPError as e:
         if e.response.status_code == 404:
@@ -252,9 +256,7 @@ async def get_form_config(request: Request, genome_id: str):
             )
         else:
             logging.error(f"VEP form config error (upstream): {e}")
-        return response_error_handler(
-            result={"status": e.response.status_code}
-        )
+        return response_error_handler(result={"status": e.response.status_code})
     except Exception as e:
         logging.error(f"VEP form config error: {e}")
         return response_error_handler(result={"status": 500})

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   tools_api:
     env_file:


### PR DESCRIPTION
### Description
Update error handling in VEP endpoints to help debugging the error root cause.

Handling flow:
1) Exceptions bubble from utility functions up to the caller (functions serving VEP endpoints). When it can, utility functions catch and add context to the error messages from upstream service before reraising.
2) Exceptions are handled by the caller depending of the exception type:
Exceptions with error messages from downstream services (Seqera cloud, metadata API) are logged and status code forwarded to the client. Internal errors are logged and 500 status sent to the client. Also added some context (caller name, error type) to the logged message.

### Related JIRA Issue(s)
[ENSWBSITES-2742](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2742)

### Review App URL(s) 
http://vep-errormsg.review.ensembl.org

### Examples

request: `api/tools/vep/submissions/2v7xiMUta5yOjM/status`
response: `200  {"workflow": {"id": "2v7xiMUta5yOjM", ...`
logs (docker output): (error content coming from `errorMessage` field in Seqera cloud response)
```bash
tools-api  | <timestamp> | ERROR | vep.vep_resources:vep_status:103 - VEP submission f2v7xiMUta5yOjM failed: f[W::bcf_hdr_parse] Could not parse header line: "#CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO"
tools-api  | [E::bcf_hdr_parse] Could not parse the header, sample line not found
tools-api  | Failed to read from interesting_single.vcf.gz: could not parse header
```
==============
request: `api/tools/vep/submissions/4mDEX0zwKr7RPL/status`
response: `200  {"workflow": {"id": "4IrKtDCJRy1XQJ", ...`
logs: (error content coming from `errorReport` field in Seqera cloud response)
```bash
tools-api  | <timestamp> | ERROR | vep.vep_resources:vep_status:103 - VEP submission f4mDEX0zwKr7RPL failed: 
<more lines>
tools-api  | ERROR ~ The specified input does not exist: <PATH>/small.vcf
tools-api  |  -- Check 'nf-4mDEX0zwKr7RPL.log' file for details
```
==============
request: `POST api/tools/vep/submissions` (with invalid genome ID)
response: `404 {"status_code": 404, ...`
logs: (error content coming from metadata API: get_vep_support_location)
```bash
tools-api  | <timestamp> | ERROR | vep.vep_resources:submit_vep:86 - VEP submission error (upstream): Could not find details for genome a7335667-93e7-11ec-a39d-005056b38 and dataset genebuild.
```
==============
request: `/api/tools/vep/form_config/<invalid_genome_id>`
response: `404  {"status_code": 404, ...`
logs: (error content coming from metadata API: get_genome_metadata)
```bash
tools-api  | <timestamp> | ERROR | vep.vep_resources:get_form_config:243 - VEP form config error (upstream): 404 Client Error: Not Found for url: https://beta.ensembl.org/api/metadata/genome/<genome_id>/dataset/genebuild/attributes?attribute_names=genebuild.provider_name&attribute_names=genebuild.display_version&attribute_names=genebuild.last_geneset_update
```

### Checklist

- [x] Black formatting
- [x] Tests

### Dependencies 
None