### PR TITLE
Update API spec

### DIFF
--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -165,7 +165,7 @@ components:
         - feature_type
         - stable_id
         - gene_stable_id
-        - symbol
+        - gene_symbol
         - biotype
         - is_canonical
         - consequences
@@ -181,7 +181,7 @@ components:
         gene_stable_id:
           type: string
           description: gene stable id, versioned
-        symbol:
+        gene_symbol:
           type: string
           nullable: true
         biotype:

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -76,13 +76,13 @@ paths:
           in: query
           required: false
           schema:
-            type: number
+            type: integer
             default: 1
         - name: per_page
           in: query
           required: false
           schema:
-            type: number
+            type: integer
             default: 100
       responses:
         '200':
@@ -140,11 +140,11 @@ components:
         - total
       properties:
         page:
-          type: number
+          type: integer
         per_page:
-          type: number
+          type: integer
         total:
-          type: number
+          type: integer
     PredictedIntergenicConsequence:
       type: object
       required:
@@ -257,9 +257,9 @@ components:
             region_name:
               type: string
             start:
-              type: number
+              type: integer
             end:
-              type: number
+              type: integer
           required:
             - region_name
             - start
@@ -305,7 +305,7 @@ components:
         - status_code
       properties:
         status_code:
-          type: number
+          type: integer
           default: 404
         details:
           type: string


### PR DESCRIPTION
### Description
- Updated a field name in the api spec (symbol -> gene_symbol)
- Updated schema type (number -> integer)

**Reference:**
- this is the name that the [client expects](https://github.com/Ensembl/ensembl-client/blob/dev/src/content/app/tools/vep/types/vepResultsResponse.ts#L61C3-L61C14)
- it was changed from `gene_symbol` to `symbol` in the spec file in [this PR](https://github.com/Ensembl/ensembl-web-tools-api/pull/13) due to a mistake on my part

### Related JIRA Issue(s)
Part of https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2781