### PR TITLE
Support path update

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,6 +32,8 @@ stages:
   rules:
     - if: $CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "main"
       when: on_success
+    - when: never
+
 
 .branch-rules-review:
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,8 +31,6 @@ stages:
 .branch-rules-main:
   rules:
     - if: $CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "main"
-      when: on_success
-    - when: never
 
 
 .branch-rules-review:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,7 @@ stages:
 .branch-rules-main:
   rules:
     - if: $CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "main"
-
+      when: on_success
 
 .branch-rules-review:
   rules:

--- a/app/vep/models/pipeline_model.py
+++ b/app/vep/models/pipeline_model.py
@@ -71,8 +71,8 @@ class ConfigIniParams(BaseModel):
 
     def create_config_ini_file(self, dir):
         vep_support_location = get_vep_support_location(self.genome_id)
-        self.gff = vep_support_location ["vep.gff_location"]
-        self.fasta = vep_support_location ["vep.gff_location"]
+        self.gff = vep_support_location["vep.gff_location"]
+        self.fasta = vep_support_location["vep.gff_location"]
         symbol = 1 if self.symbol else 0
         biotype = 1 if self.biotype else 0
 

--- a/app/vep/models/pipeline_model.py
+++ b/app/vep/models/pipeline_model.py
@@ -66,13 +66,13 @@ class ConfigIniParams(BaseModel):
     biotype: bool = False
     transcript_version: int = 1
     canonical: int = 1
-    gff: str = "genes.gff3.bgz"
-    fasta: str = "unmasked.fa.bgz"
+    gff: str = ""
+    fasta: str = ""
 
     def create_config_ini_file(self, dir):
         vep_support_location = get_vep_support_location(self.genome_id)
-        self.gff = vep_support_location + self.gff
-        self.fasta = vep_support_location + self.fasta
+        self.gff = vep_support_location ["vep.gff_location"]
+        self.fasta = vep_support_location ["vep.gff_location"]
         symbol = 1 if self.symbol else 0
         biotype = 1 if self.biotype else 0
 

--- a/app/vep/utils/web_metadata.py
+++ b/app/vep/utils/web_metadata.py
@@ -1,4 +1,5 @@
 import requests
+
 from vep.models.submission_form import GenomeAnnotationProvider
 
 from core.config import WEB_METADATA_API, VEP_SUPPORT_PATH
@@ -6,14 +7,20 @@ from core.config import WEB_METADATA_API, VEP_SUPPORT_PATH
 
 def get_vep_support_location(genome_id: str) -> str:
     try:
+        results_dict: dict = {}
         response = requests.get(
             WEB_METADATA_API
             + "genome/"
             + genome_id
-            + "/dataset/genebuild/attributes?attribute_names=vep.bgz_location"
+            + "/dataset/genebuild/attributes?attribute_names=vep.faa_location&attribute_names=vep.gff_location"
         )
         response.raise_for_status()
-        return VEP_SUPPORT_PATH + response.json()["attributes"].pop()["value"]
+        for result in response.json()["attributes"]:
+            if result["name"] == "vep.faa_location":
+                results_dict ["vep.faa_location"] = VEP_SUPPORT_PATH + result["value"]
+            else:
+                results_dict["vep.gff_location"] = VEP_SUPPORT_PATH + result["value"]
+        return results_dict
     except KeyError as e:
         e.args = (
             f"get_vep_support_location(): unexpected metadata API payload for f{genome_id}:",

--- a/app/vep/utils/web_metadata.py
+++ b/app/vep/utils/web_metadata.py
@@ -17,7 +17,7 @@ def get_vep_support_location(genome_id: str) -> str:
         response.raise_for_status()
         for result in response.json()["attributes"]:
             if result["name"] == "vep.faa_location":
-                results_dict ["vep.faa_location"] = VEP_SUPPORT_PATH + result["value"]
+                results_dict["vep.faa_location"] = VEP_SUPPORT_PATH + result["value"]
             else:
                 results_dict["vep.gff_location"] = VEP_SUPPORT_PATH + result["value"]
         return results_dict


### PR DESCRIPTION
### Description
Production want to split the VEP support dataset attribute vep.bgz_location into two entries, one for GFF vep.gff_location and one for FASTA vep.faa_location. Update Tools API's get_vep_support_location method to support these two new attributes

### Related JIRA Issue(s)
[ENSWBSITES-2802](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2802)

### Review App URL(s) 
http://__BRANCH_NAME_HERE__.review.ensembl.org

### Knowledge Base
<!--
_If the PR introduces new concept, then provide link(s) to the Knowledge base ( Documentation, Blog etc )_
-->

### Example(s)
<!--
_Any details that will help reviewers to review the PR, such as  (but not limited to ) expected request/response, instruction for viewing the changes via the web client, or any other relevant information._
-->

### Checklist

- [ ] Black formatting
- [ ] Tests

### Dependencies 
<!--
_Does it need anything else before the PR gets merged. May be data update, k8s config update, PR in another repository_
-->