### PR TITLE
Update `get_vep_support_location`

### DIFF
--- a/app/vep/models/pipeline_model.py
+++ b/app/vep/models/pipeline_model.py
@@ -69,10 +69,10 @@ class ConfigIniParams(BaseModel):
     gff: str = ""
     fasta: str = ""
 
-    def create_config_ini_file(self, dir):
+    def create_config_ini_file(self, directory):
         vep_support_location = get_vep_support_location(self.genome_id)
-        self.gff = vep_support_location["vep.gff_location"]
-        self.fasta = vep_support_location["vep.faa_location"]
+        self.gff = vep_support_location["gff_location"]
+        self.fasta = vep_support_location["faa_location"]
         symbol = 1 if self.symbol else 0
         biotype = 1 if self.biotype else 0
 
@@ -86,7 +86,7 @@ gff {self.gff}
 fasta {self.fasta}
 """
         try:
-            with open(os.path.join(dir, "config.ini"), "w") as ini_file:
+            with open(os.path.join(directory, "config.ini"), "w") as ini_file:
                 ini_file.write(config_ini)
             return ini_file
         except Exception as e:

--- a/app/vep/utils/web_metadata.py
+++ b/app/vep/utils/web_metadata.py
@@ -5,22 +5,20 @@ from vep.models.submission_form import GenomeAnnotationProvider
 from core.config import WEB_METADATA_API, VEP_SUPPORT_PATH
 
 
-def get_vep_support_location(genome_id: str) -> str:
+def get_vep_support_location(genome_id: str) -> dict:
     try:
-        results_dict: dict = {}
         response = requests.get(
             WEB_METADATA_API
             + "genome/"
             + genome_id
-            + "/dataset/genebuild/attributes?attribute_names=vep.faa_location&attribute_names=vep.gff_location"
+            + "/vep/file_paths"
         )
         response.raise_for_status()
-        for result in response.json()["attributes"]:
-            if result["name"] == "vep.faa_location":
-                results_dict["vep.faa_location"] = VEP_SUPPORT_PATH + result["value"]
-            else:
-                results_dict["vep.gff_location"] = VEP_SUPPORT_PATH + result["value"]
-        return results_dict
+        data = response.json()
+        return {
+            "faa_location": f"{VEP_SUPPORT_PATH}{data['faa_location']}",
+            "gff_location": f"{VEP_SUPPORT_PATH}{data['gff_location']}",
+        }
     except KeyError as e:
         e.args = (
             f"get_vep_support_location(): unexpected metadata API payload for f{genome_id}:",


### PR DESCRIPTION
### Description
Update `get_vep_support_location` to reflect the changes done in this PR: https://github.com/Ensembl/ensembl-web-metadata-api/pull/64

### Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/EA-1309

### Review App URL(s) 
http://update-vep-paths.review.ensembl.org/ (I don't know if/how this works)

### Example
This is how the files locations might look like in the config file:
```
gff /nfs/public/ro/enswbsites/dev/vep/support/Homo_sapiens/GCA_000001405.14/vep/genome/softmasked.fa.bgz
fasta /nfs/public/ro/enswbsites/dev/vep/support/Homo_sapiens/GCA_000001405.14/vep/ensembl/geneset/2013_09/genes.gff3.bgz'
```

### Dependencies 
The follwing PRs need to be merged first
1. [Meatadata API + gRPC] https://github.com/Ensembl/ensembl-metadata-api/pull/126
2. [Metadata Web API] https://github.com/Ensembl/ensembl-web-metadata-api/pull/64