### PR TITLE
Fix VEP version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__
 .idea*
 .env
 .vscode
+.DS_Store
 report.xml
 tmpdir/
 venv*

--- a/app/vep/models/pipeline_model.py
+++ b/app/vep/models/pipeline_model.py
@@ -27,7 +27,7 @@ class VEPConfigParams(BaseModel):
     outdir: DirectoryPath
     bin_size: int = 3000
     sort: bool = True
-    vep_version: str = "114.0"
+    vep_version: str = "115.0"
 
     @model_serializer
     def vep_config_serialiser(self):
@@ -47,7 +47,7 @@ class LaunchParams(BaseModel):
     computeEnvId: str = NF_COMPUTE_ENV_ID
     pipeline: str = NF_PIPELINE_URL
     workDir: DirectoryPath
-    revision: str = "release/114"
+    revision: str = "release/115"
     pullLatest: bool = True
     configProfiles: list[str] = ["ensembl"]
     paramsText: VEPConfigParams

--- a/app/vep/models/pipeline_model.py
+++ b/app/vep/models/pipeline_model.py
@@ -27,7 +27,7 @@ class VEPConfigParams(BaseModel):
     outdir: DirectoryPath
     bin_size: int = 3000
     sort: bool = True
-    vep_version: str = "113.0"
+    vep_version: str = "114.0"
 
     @model_serializer
     def vep_config_serialiser(self):
@@ -47,7 +47,7 @@ class LaunchParams(BaseModel):
     computeEnvId: str = NF_COMPUTE_ENV_ID
     pipeline: str = NF_PIPELINE_URL
     workDir: DirectoryPath
-    revision: str = "main"
+    revision: str = "release/114"
     pullLatest: bool = True
     configProfiles: list[str] = ["ensembl"]
     paramsText: VEPConfigParams

--- a/app/vep/models/pipeline_model.py
+++ b/app/vep/models/pipeline_model.py
@@ -27,7 +27,7 @@ class VEPConfigParams(BaseModel):
     outdir: DirectoryPath
     bin_size: int = 3000
     sort: bool = True
-    vep_version: str = "114.2"
+    vep_version: str = "114.0"
 
     @model_serializer
     def vep_config_serialiser(self):

--- a/app/vep/models/pipeline_model.py
+++ b/app/vep/models/pipeline_model.py
@@ -27,7 +27,7 @@ class VEPConfigParams(BaseModel):
     outdir: DirectoryPath
     bin_size: int = 3000
     sort: bool = True
-    vep_version: str = "115"
+    vep_version: str = "115.0"
 
     @model_serializer
     def vep_config_serialiser(self):

--- a/app/vep/models/pipeline_model.py
+++ b/app/vep/models/pipeline_model.py
@@ -84,7 +84,7 @@ transcript_version {self.transcript_version}
 canonical {self.canonical}
 gff {self.gff}
 fasta {self.fasta}
-vep_version 115
+vep_version 114
 """
         try:
             with open(os.path.join(directory, "config.ini"), "w") as ini_file:

--- a/app/vep/models/pipeline_model.py
+++ b/app/vep/models/pipeline_model.py
@@ -27,6 +27,7 @@ class VEPConfigParams(BaseModel):
     outdir: DirectoryPath
     bin_size: int = 3000
     sort: bool = True
+    vep_version: str = "115"
 
     @model_serializer
     def vep_config_serialiser(self):
@@ -35,8 +36,9 @@ class VEPConfigParams(BaseModel):
         outdir_str = f'"outdir": "{self.outdir.as_posix()}"'
         bin_str = f'"bin_size": {self.bin_size}'
         sort_str = f'"sort": {"true" if self.sort else "false"}'
+        vep_version_str = f'"vep_version": "{self.vep_version}"'
         json_str = (
-            "{" + ", ".join([vcf_str, config_str, outdir_str, bin_str, sort_str]) + "}"
+            "{" + ", ".join([vcf_str, config_str, outdir_str, bin_str, sort_str, vep_version_str]) + "}"
         )
         return json_str
 
@@ -84,7 +86,6 @@ transcript_version {self.transcript_version}
 canonical {self.canonical}
 gff {self.gff}
 fasta {self.fasta}
-vep_version 114
 """
         try:
             with open(os.path.join(directory, "config.ini"), "w") as ini_file:

--- a/app/vep/models/pipeline_model.py
+++ b/app/vep/models/pipeline_model.py
@@ -27,7 +27,7 @@ class VEPConfigParams(BaseModel):
     outdir: DirectoryPath
     bin_size: int = 3000
     sort: bool = True
-    vep_version: str = "115.0"
+    vep_version: str = "114.2"
 
     @model_serializer
     def vep_config_serialiser(self):

--- a/app/vep/models/pipeline_model.py
+++ b/app/vep/models/pipeline_model.py
@@ -27,7 +27,7 @@ class VEPConfigParams(BaseModel):
     outdir: DirectoryPath
     bin_size: int = 3000
     sort: bool = True
-    vep_version: str = "114.0"
+    vep_version: str = "113.0"
 
     @model_serializer
     def vep_config_serialiser(self):

--- a/app/vep/models/pipeline_model.py
+++ b/app/vep/models/pipeline_model.py
@@ -84,6 +84,7 @@ transcript_version {self.transcript_version}
 canonical {self.canonical}
 gff {self.gff}
 fasta {self.fasta}
+vep_version 115
 """
         try:
             with open(os.path.join(directory, "config.ini"), "w") as ini_file:


### PR DESCRIPTION
### Description
This PR updates VEP pipeline configuration in Tools API to fix the pipeline repo branch and VEP image version to 115.
This should fix an issue where pulling the latest repo/image version (as default) breaks the VEP pipelines on beta site.
Context: [Slack thread](https://genomes-ebi.slack.com/archives/CC2RKR525/p1780578917829679)
Review app: https://hotfix-vep-release-param.review.ensembl.org
